### PR TITLE
chore: Stop uploading indexes to k8s.sgdev.org

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -38,10 +38,6 @@ jobs:
         run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
-      - name: Upload lsif to Dogfood
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
       - name: Upload lsif to Demo
         run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:


### PR DESCRIPTION
I cannot push a branch to the main repo directly, so I've created this PR from a fork.