### PR TITLE
docs: link to OpenCodeGraph blog post

### DIFF
--- a/web/content/docs/community.mdx
+++ b/web/content/docs/community.mdx
@@ -17,4 +17,4 @@ export const info = {
 
 ## Mentions from around the web
 
-- [Hack with us on OpenCtx, an experimental OSS project for code context](https://sourcegraph.com/blog/openctx) (announcement post)
+- [Hack with us on OpenCodeGraph, an experimental OSS project for code context](https://sourcegraph.com/blog/opencodegraph) (announcement post)

--- a/web/content/docs/start.mdx
+++ b/web/content/docs/start.mdx
@@ -8,7 +8,7 @@ export const info = {
 
 # Get started with OpenCtx
 
-OpenCtx shows you contextual info about code from your dev tools, in your editor, in code review, and anywhere else you read code ([announcement blog post](https://sourcegraph.com/blog/openctx)).
+OpenCtx shows you contextual info about code from your dev tools, in your editor, in code review, and anywhere else you read code ([announcement blog post](https://sourcegraph.com/blog/opencodegraph)).
 
 You can use OpenCtx in:
 


### PR DESCRIPTION
I think the link was accidently updated when the project was renamed. The old link here was a 404.