### PR TITLE
Update protocol to support context integration with Cody

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,8 @@
   },
   "openctx.providers": {
     // "https://sourcegraph.test:3443/.api/openctx": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/bin/cli.mts
+++ b/bin/cli.mts
@@ -11,7 +11,9 @@ import { of } from 'rxjs'
 function usageFatal(message: string): never {
     console.error(message)
     console.error(
-        `\nUsage: OPENCTX_CONFIG=<config> ${path.basename(process.argv[1])} capabilities|mentions|items [args...]`
+        `\nUsage: OPENCTX_CONFIG=<config> ${path.basename(
+            process.argv[1]
+        )} capabilities|mentions|items [args...]`
     )
     process.exit(1)
 }

--- a/bin/cli.mts
+++ b/bin/cli.mts
@@ -11,7 +11,7 @@ import { of } from 'rxjs'
 function usageFatal(message: string): never {
     console.error(message)
     console.error(
-        `\nUsage: OPENCTX_CONFIG=<config> ${path.basename(process.argv[1])} items [query] [mentionJSON]`
+        `\nUsage: OPENCTX_CONFIG=<config> ${path.basename(process.argv[1])} capabilities|mentions|items [args...]`
     )
     process.exit(1)
 }

--- a/bin/cli.mts
+++ b/bin/cli.mts
@@ -1,20 +1,53 @@
 import path from 'path'
-import { type Client, type ClientConfiguration, type Range, createClient } from '@openctx/client'
+import {
+    type Client,
+    type ClientConfiguration,
+    type Mention,
+    type Range,
+    createClient,
+} from '@openctx/client'
 import { of } from 'rxjs'
 
 function usageFatal(message: string): never {
     console.error(message)
-    console.error(`\nUsage: OPENCTX_CONFIG=<config> ${path.basename(process.argv[1])} items [query]`)
+    console.error(
+        `\nUsage: OPENCTX_CONFIG=<config> ${path.basename(process.argv[1])} items [query] [mentionJSON]`
+    )
     process.exit(1)
+}
+
+async function subcommandMentions(client: Client<Range>, args: string[]): Promise<void> {
+    if (args.length !== 1) {
+        usageFatal('Error: the "mentions" subcommand expects one argument "query"')
+    }
+    const [query] = args
+
+    const mentions = await client.mentions({ query })
+
+    if (process.env.OUTPUT_JSON) {
+        console.log(JSON.stringify(mentions, null, 2))
+    } else {
+        for (const [i, item] of mentions.entries()) {
+            console.log(`#${i + 1} ${item.title}${item.uri ? ` — ${item.uri}` : ''}`)
+            if (item.data) {
+                console.log(JSON.stringify(item.data, null, 2))
+            }
+        }
+    }
 }
 
 async function subcommandItems(client: Client<Range>, args: string[]): Promise<void> {
     if (args.length !== 1) {
         usageFatal('Error: the "items" subcommand expects one argument "query"')
     }
-    const [query] = args
+    const [message, mentionJSON] = args
 
-    const items = await client.items({ query })
+    let mention: Mention | undefined
+    if (mentionJSON) {
+        mention = JSON.parse(mentionJSON)
+    }
+
+    const items = await client.items({ message, mention })
 
     if (process.env.OUTPUT_JSON) {
         console.log(JSON.stringify(items, null, 2))
@@ -67,6 +100,9 @@ const args = process.argv.slice(3)
 switch (subcommand) {
     case 'items':
         await subcommandItems(client, args)
+        break
+    case 'mentions':
+        await subcommandMentions(client, args)
         break
     default:
         usageFatal('Error: only the "capabilities" or "items" subcommand is supported')

--- a/client/vscode-lib/src/controller.test.ts
+++ b/client/vscode-lib/src/controller.test.ts
@@ -3,11 +3,19 @@ import type { Controller } from './controller'
 
 export function createMockController(): MockedObject<Controller> {
     return {
+        observeCapabilities: vi.fn(),
+        capabilities: vi.fn(),
+        observeMentions: vi.fn(),
+        mentions: vi.fn(),
         observeItems: vi.fn(),
         items: vi.fn(),
         observeAnnotations: vi.fn(),
         annotations: vi.fn(),
         client: {
+            capabilitiesChanges: vi.fn(),
+            capabilities: vi.fn(),
+            mentions: vi.fn(),
+            mentionsChanges: vi.fn(),
             itemsChanges: vi.fn(),
             items: vi.fn(),
             annotationsChanges: vi.fn(),

--- a/lib/client/src/client/client.test.ts
+++ b/lib/client/src/client/client.test.ts
@@ -3,7 +3,7 @@ import type { Item, Range } from '@openctx/schema'
 import { firstValueFrom, of } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { describe, expect, test } from 'vitest'
-import type { Annotation } from '../api'
+import type { Annotation, EachWithProviderUri } from '../api'
 import type { ConfigurationUserInput } from '../configuration'
 import { type Client, type ClientEnv, createClient } from './client'
 
@@ -52,7 +52,9 @@ describe('Client', () => {
             })
 
             const items = await client.items(FIXTURE_ITEMS_PARAMS)
-            expect(items).toStrictEqual<typeof items>([{ title: 'A' }])
+            expect(items).toStrictEqual<typeof items>([
+                { title: 'A', providerUri: testdataFileUri('simple.js') },
+            ])
         })
 
         test('no providers', async () => {
@@ -74,10 +76,21 @@ describe('Client', () => {
                                 a: { enable: true, providers: { [testdataFileUri('simple.js')]: {} } },
                             }),
                         __mock__: {
-                            getProviderClient: () => ({ items: () => of([fixtureItem('a')]) }),
+                            getProviderClient: () => ({
+                                items: () =>
+                                    of([
+                                        {
+                                            ...fixtureItem('a'),
+                                            providerUri: testdataFileUri('simple.js'),
+                                        },
+                                    ]),
+                            }),
                         },
                     }).itemsChanges(FIXTURE_ITEMS_PARAMS)
-                ).toBe('(0a)', { '0': [], a: [fixtureItem('a')] } satisfies Record<string, Item[]>)
+                ).toBe('(0a)', {
+                    '0': [],
+                    a: [{ ...fixtureItem('a'), providerUri: testdataFileUri('simple.js') }],
+                } satisfies Record<string, EachWithProviderUri<Item[]>>)
             })
         })
     })
@@ -95,6 +108,7 @@ describe('Client', () => {
                     uri: FIXTURE_ANNOTATIONS_PARAMS.uri,
                     range: { start: { line: 1, character: 2 }, end: { line: 3, character: 4 } },
                     item: { title: 'A' },
+                    providerUri: testdataFileUri('simple.js'),
                 },
             ])
         })
@@ -121,7 +135,10 @@ describe('Client', () => {
                             getProviderClient: () => ({ annotations: () => of([fixtureAnn('a')]) }),
                         },
                     }).annotationsChanges(FIXTURE_ANNOTATIONS_PARAMS)
-                ).toBe('(0a)', { '0': [], a: [fixtureAnn('a')] } satisfies Record<string, Annotation[]>)
+                ).toBe('(0a)', {
+                    '0': [],
+                    a: [{ ...fixtureAnn('a'), providerUri: testdataFileUri('simple.js') }],
+                } satisfies Record<string, EachWithProviderUri<Annotation[]>>)
             })
         })
     })

--- a/lib/client/src/client/client.ts
+++ b/lib/client/src/client/client.ts
@@ -327,7 +327,6 @@ export function createClient<R extends Range>(env: ClientEnv<R>): Client<R> {
         )
     }
 
-    // TODO: add option to get candidate items from a specific provider.
     const mentionsChanges = (
         params: MentionsParams,
         { emitPartial }: ObserveOptions,
@@ -343,7 +342,6 @@ export function createClient<R extends Range>(env: ClientEnv<R>): Client<R> {
         )
     }
 
-    // TODO: add option to get items from a specific provider.
     const itemsChanges = (
         params: ItemsParams,
         { emitPartial }: ObserveOptions,

--- a/lib/client/src/client/client.ts
+++ b/lib/client/src/client/client.ts
@@ -1,6 +1,14 @@
-import type { AnnotationsParams, ItemsParams } from '@openctx/protocol'
+import type {
+    AnnotationsParams,
+    CapabilitiesParams,
+    CapabilitiesResult,
+    ItemsParams,
+    ItemsResult,
+    MentionsParams,
+    MentionsResult,
+} from '@openctx/protocol'
 import type { Provider } from '@openctx/provider'
-import type { Item, Range } from '@openctx/schema'
+import type { Range } from '@openctx/schema'
 import { LRUCache } from 'lru-cache'
 import {
     type Observable,
@@ -18,11 +26,14 @@ import {
 } from 'rxjs'
 import {
     type Annotation,
+    type EachWithProviderUri,
     type ObservableProviderClient,
     type ObserveOptions,
     type ProviderClientWithSettings,
     observeAnnotations,
+    observeCapabilities,
     observeItems,
+    observeMentions,
 } from '../api'
 import { type ConfigurationUserInput, configurationFromUserInput } from '../configuration'
 import type { Logger } from '../logger'
@@ -113,6 +124,51 @@ export interface AuthInfo {
  */
 export interface Client<R extends Range> {
     /**
+     * Get the capabilities returned by the configured providers.
+     *
+     * It does not continue to listen for changes, as {@link Client.capabilitiesChanges} does. Using
+     * {@link Client.capabilities} is simpler and does not require use of observables (with a library like
+     * RxJS), but it means that the client needs to manually poll for updated item kinds if freshness is
+     * important.
+     */
+    capabilities(
+        params: CapabilitiesParams,
+        providerUri?: string
+    ): Promise<EachWithProviderUri<CapabilitiesResult[]>>
+
+    /**
+     * Observe OpenCtx capabilities of the configured providers.
+     *
+     * The returned observable streams capabilities as they are received from the providers and continues
+     * passing along any updates until unsubscribed.
+     */
+    capabilitiesChanges(
+        params: CapabilitiesParams,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<CapabilitiesResult[]>>
+
+    /**
+     * Get the candidate items returned by the configured providers.
+     *
+     * It does not continue to listen for changes, as {@link Client.mentionsChanges} does. Using
+     * {@link Client.Mentions} is simpler and does not require use of observables (with a library like
+     * RxJS), but it means that the client needs to manually poll for updated items if freshness is
+     * important.
+     */
+    mentions(params: MentionsParams, providerUri?: string): Promise<EachWithProviderUri<MentionsResult>>
+
+    /**
+     * Observe OpenCtx candidate items from the configured providers.
+     *
+     * The returned observable streams candidate items as they are received from the providers and continues
+     * passing along any updates until unsubscribed.
+     */
+    mentionsChanges(
+        params: MentionsParams,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<MentionsResult>>
+
+    /**
      * Get the items returned by the configured providers.
      *
      * It does not continue to listen for changes, as {@link Client.itemsChanges} does. Using
@@ -120,7 +176,7 @@ export interface Client<R extends Range> {
      * RxJS), but it means that the client needs to manually poll for updated items if freshness is
      * important.
      */
-    items(params: ItemsParams): Promise<Item[]>
+    items(params: ItemsParams, providerUri?: string): Promise<EachWithProviderUri<ItemsResult>>
 
     /**
      * Observe OpenCtx items from the configured providers.
@@ -128,7 +184,7 @@ export interface Client<R extends Range> {
      * The returned observable streams items as they are received from the providers and continues
      * passing along any updates until unsubscribed.
      */
-    itemsChanges(params: ItemsParams): Observable<Item[]>
+    itemsChanges(params: ItemsParams, providerUri?: string): Observable<EachWithProviderUri<ItemsResult>>
 
     /**
      * Get the annotations returned by the configured providers for the given resource.
@@ -138,7 +194,10 @@ export interface Client<R extends Range> {
      * like RxJS), but it means that the client needs to manually poll for updated annotations if
      * freshness is important.
      */
-    annotations(params: AnnotationsParams): Promise<Annotation<R>[]>
+    annotations(
+        params: AnnotationsParams,
+        providerUri?: string
+    ): Promise<EachWithProviderUri<Annotation<R>[]>>
 
     /**
      * Observe OpenCtx annotations from the configured providers for the given resource.
@@ -146,7 +205,10 @@ export interface Client<R extends Range> {
      * The returned observable streams annotations as they are received from the providers and
      * continues passing along any updates until unsubscribed.
      */
-    annotationsChanges(params: AnnotationsParams): Observable<Annotation<R>[]>
+    annotationsChanges(
+        params: AnnotationsParams,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<Annotation<R>[]>>
 
     /**
      * Dispose of the client and release all resources.
@@ -200,6 +262,7 @@ export function createClient<R extends Range>(env: ClientEnv<R>): Client<R> {
                               configuration.providers.map(({ providerUri, settings }) =>
                                   (env.authInfo ? from(env.authInfo(providerUri)) : of(null)).pipe(
                                       map(authInfo => ({
+                                          uri: providerUri,
                                           providerClient: env.__mock__?.getProviderClient
                                               ? env.__mock__.getProviderClient()
                                               : providerCache.getOrCreate(
@@ -236,31 +299,104 @@ export function createClient<R extends Range>(env: ClientEnv<R>): Client<R> {
             )
     }
 
-    const itemsChanges = (params: ItemsParams, { emitPartial }: ObserveOptions): Observable<Item[]> => {
-        return observeItems(providerClientsWithSettings(undefined), params, {
-            logger: env.logger,
-            emitPartial,
-        })
+    const filterProviders = (
+        providersObservable: Observable<ProviderClientWithSettings[]>,
+        uri?: string
+    ): Observable<ProviderClientWithSettings[]> => {
+        if (!uri) {
+            return providersObservable
+        }
+
+        return providersObservable.pipe(
+            map(providers => providers.filter(provider => provider.uri === uri))
+        )
+    }
+
+    const capabilitiesChanges = (
+        params: CapabilitiesParams,
+        { emitPartial }: ObserveOptions,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<CapabilitiesResult[]>> => {
+        return observeCapabilities(
+            filterProviders(providerClientsWithSettings(undefined), providerUri),
+            params,
+            {
+                logger: env.logger,
+                emitPartial,
+            }
+        )
+    }
+
+    // TODO: add option to get candidate items from a specific provider.
+    const mentionsChanges = (
+        params: MentionsParams,
+        { emitPartial }: ObserveOptions,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<MentionsResult>> => {
+        return observeMentions(
+            filterProviders(providerClientsWithSettings(undefined), providerUri),
+            params,
+            {
+                logger: env.logger,
+                emitPartial,
+            }
+        )
+    }
+
+    // TODO: add option to get items from a specific provider.
+    const itemsChanges = (
+        params: ItemsParams,
+        { emitPartial }: ObserveOptions,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<ItemsResult>> => {
+        return observeItems(
+            filterProviders(providerClientsWithSettings(undefined), providerUri),
+            params,
+            {
+                logger: env.logger,
+                emitPartial,
+            }
+        )
     }
 
     const annotationsChanges = (
         params: AnnotationsParams,
-        { emitPartial }: ObserveOptions
-    ): Observable<Annotation<R>[]> => {
-        return observeAnnotations(providerClientsWithSettings(params.uri), params, {
-            logger: env.logger,
-            makeRange: env.makeRange,
-            emitPartial,
-        })
+        { emitPartial }: ObserveOptions,
+        providerUri?: string
+    ): Observable<EachWithProviderUri<Annotation<R>[]>> => {
+        return observeAnnotations(
+            filterProviders(providerClientsWithSettings(params.uri), providerUri),
+            params,
+            {
+                logger: env.logger,
+                makeRange: env.makeRange,
+                emitPartial,
+            }
+        )
     }
 
     return {
-        items: params =>
-            firstValueFrom(itemsChanges(params, { emitPartial: false }), { defaultValue: [] }),
-        itemsChanges: params => itemsChanges(params, { emitPartial: true }),
-        annotations: params =>
-            firstValueFrom(annotationsChanges(params, { emitPartial: false }), { defaultValue: [] }),
-        annotationsChanges: params => annotationsChanges(params, { emitPartial: true }),
+        capabilities: (params, providerUri) =>
+            firstValueFrom(capabilitiesChanges(params, { emitPartial: false }, providerUri), {
+                defaultValue: [],
+            }),
+        capabilitiesChanges: (params, providerUri) =>
+            capabilitiesChanges(params, { emitPartial: true }, providerUri),
+        mentions: params =>
+            firstValueFrom(mentionsChanges(params, { emitPartial: false }), { defaultValue: [] }),
+        mentionsChanges: (params, providerUri) =>
+            mentionsChanges(params, { emitPartial: true }, providerUri),
+        items: (params, providerUri) =>
+            firstValueFrom(itemsChanges(params, { emitPartial: false }, providerUri), {
+                defaultValue: [],
+            }),
+        itemsChanges: (params, providerUri) => itemsChanges(params, { emitPartial: true }, providerUri),
+        annotations: (params, providerUri) =>
+            firstValueFrom(annotationsChanges(params, { emitPartial: false }, providerUri), {
+                defaultValue: [],
+            }),
+        annotationsChanges: (params, providerUri) =>
+            annotationsChanges(params, { emitPartial: true }, providerUri),
         dispose() {
             for (const sub of subscriptions) {
                 sub.unsubscribe()

--- a/lib/client/src/index.ts
+++ b/lib/client/src/index.ts
@@ -1,7 +1,7 @@
 export type * from '@openctx/protocol'
 export type { Provider } from '@openctx/provider'
 export type * from '@openctx/schema'
-export { observeItems, type Annotation } from './api'
+export { observeItems, type Annotation, type EachWithProviderUri } from './api'
 export { createClient, type AuthInfo, type Client, type ClientEnv } from './client/client'
 export { type ConfigurationUserInput as ClientConfiguration } from './configuration'
 export type { Logger } from './logger'

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -1,8 +1,12 @@
 import type {
     AnnotationsParams,
     AnnotationsResult,
+    CapabilitiesParams,
+    CapabilitiesResult,
     ItemsParams,
     ItemsResult,
+    MentionsParams,
+    MentionsResult,
     ProviderSettings,
 } from '@openctx/protocol'
 import { scopedLogger } from '../logger'
@@ -14,6 +18,12 @@ import { type ProviderTransportOptions, createTransport } from './transport/crea
  * wraps a {@link ProviderTransport}.
  */
 export interface ProviderClient {
+    /** Get capabilities from the provider. */
+    capabilities(params: MentionsParams, settings: ProviderSettings): Promise<CapabilitiesResult>
+
+    /** Get candidate items from the provider. */
+    mentions(params: MentionsParams, settings: ProviderSettings): Promise<MentionsResult | null>
+
     /** Get items from the provider. */
     items(params: ItemsParams, settings: ProviderSettings): Promise<ItemsResult | null>
 
@@ -43,6 +53,28 @@ export function createProviderClient(
     const transport = createTransport(providerUri, { ...options, cache: true, logger })
 
     return {
+        async capabilities(
+            params: CapabilitiesParams,
+            settings: ProviderSettings
+        ): Promise<CapabilitiesResult> {
+            try {
+                return await transport.capabilities(params, settings)
+            } catch (error) {
+                logger?.(`failed to get item kinds: ${error}`)
+                return Promise.reject(error)
+            }
+        },
+        async mentions(
+            params: MentionsParams,
+            settings: ProviderSettings
+        ): Promise<MentionsResult | null> {
+            try {
+                return await transport.mentions(params, settings)
+            } catch (error) {
+                logger?.(`failed to get candidate items: ${error}`)
+                return Promise.reject(error)
+            }
+        },
         async items(params: ItemsParams, settings: ProviderSettings): Promise<ItemsResult | null> {
             try {
                 return await transport.items(params, settings)

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -71,7 +71,7 @@ export function createProviderClient(
             try {
                 return await transport.mentions(params, settings)
             } catch (error) {
-                logger?.(`failed to get candidate items: ${error}`)
+                logger?.(`failed to get mentions: ${error}`)
                 return Promise.reject(error)
             }
         },

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -60,7 +60,7 @@ export function createProviderClient(
             try {
                 return await transport.capabilities(params, settings)
             } catch (error) {
-                logger?.(`failed to get item kinds: ${error}`)
+                logger?.(`failed to get capabilities: ${error}`)
                 return Promise.reject(error)
             }
         },

--- a/lib/client/src/providerClient/transport/cache.ts
+++ b/lib/client/src/providerClient/transport/cache.ts
@@ -30,6 +30,10 @@ export function cachedTransport(provider: ProviderTransport): ProviderTransport 
             cachedMethodCall('capabilities', args, (params, settings) =>
                 provider.capabilities(params, settings)
             ),
+        mentions: (...args) =>
+            cachedMethodCall('mentions', args, (params, settings) =>
+                provider.mentions(params, settings)
+            ),
         items: (...args) =>
             cachedMethodCall('items', args, (params, settings) => provider.items(params, settings)),
         annotations: (...args) =>

--- a/lib/client/src/providerClient/transport/createTransport.test.ts
+++ b/lib/client/src/providerClient/transport/createTransport.test.ts
@@ -8,6 +8,7 @@ import { type ProviderTransport, createTransport } from './createTransport'
 async function expectProviderTransport(provider: ProviderTransport) {
     expect(await provider.capabilities({}, {})).toEqual<CapabilitiesResult>({
         selector: [{ path: 'foo' }],
+        meta: { name: 'foo' },
     })
 }
 
@@ -55,13 +56,19 @@ describe('createTransport', () => {
                     expect(uri).toBe('file:///myProvider.js')
                     return Promise.resolve({
                         default: {
-                            capabilities: () => ({ selector: [{ path: 'asdf' }] }),
+                            capabilities: () => ({
+                                selector: [{ path: 'asdf' }],
+                                meta: { name: 'foo' },
+                            }),
                             items: () => [],
                         },
                     })
                 },
             })
-            expect(await provider.capabilities({}, {})).toEqual({ selector: [{ path: 'asdf' }] })
+            expect(await provider.capabilities({}, {})).toEqual({
+                selector: [{ path: 'asdf' }],
+                meta: { name: 'foo' },
+            })
         })
 
         test('dynamicImportFromUri remote', async () => {
@@ -70,13 +77,19 @@ describe('createTransport', () => {
                     expect(uri).toBe('http://example.com/myProvider.js')
                     return Promise.resolve({
                         default: {
-                            capabilities: () => ({ selector: [{ path: 'asdf' }] }),
+                            capabilities: () => ({
+                                selector: [{ path: 'asdf' }],
+                                meta: { name: 'foo' },
+                            }),
                             items: () => [],
                         },
                     })
                 },
             })
-            expect(await provider.capabilities({}, {})).toEqual({ selector: [{ path: 'asdf' }] })
+            expect(await provider.capabilities({}, {})).toEqual({
+                selector: [{ path: 'asdf' }],
+                meta: { name: 'foo' },
+            })
         })
 
         test('dynamicImportFromSource', async () => {
@@ -90,14 +103,20 @@ describe('createTransport', () => {
                     return Promise.resolve({
                         exports: {
                             default: {
-                                capabilities: () => ({ selector: [{ path: 'asdf' }] }),
+                                capabilities: () => ({
+                                    selector: [{ path: 'asdf' }],
+                                    meta: { name: 'foo' },
+                                }),
                                 items: () => [],
                             },
                         },
                     })
                 },
             })
-            expect(await provider.capabilities({}, {})).toEqual({ selector: [{ path: 'asdf' }] })
+            expect(await provider.capabilities({}, {})).toEqual({
+                selector: [{ path: 'asdf' }],
+                meta: { name: 'foo' },
+            })
         })
     })
 
@@ -143,7 +162,10 @@ describe('createTransport', () => {
         test('simple', async () => {
             fetchMocker.mockOnce(
                 JSON.stringify({
-                    result: { selector: [{ path: 'foo' }] } satisfies CapabilitiesResult,
+                    result: {
+                        selector: [{ path: 'foo' }],
+                        meta: { name: 'foo' },
+                    } satisfies CapabilitiesResult,
                 } satisfies ResponseMessage)
             )
             const provider = createTransport('https://example.com/openctx', {})

--- a/lib/client/src/providerClient/transport/http.ts
+++ b/lib/client/src/providerClient/transport/http.ts
@@ -2,6 +2,7 @@ import type {
     AnnotationsResult,
     CapabilitiesResult,
     ItemsResult,
+    MentionsResult,
     RequestMessage,
     ResponseMessage,
 } from '@openctx/protocol'
@@ -85,6 +86,7 @@ export function createHttpTransport(
 
     return {
         capabilities: async params => send<CapabilitiesResult>({ method: 'capabilities', params }),
+        mentions: async params => send<MentionsResult>({ method: 'mentions', params }),
         items: async params => send<ItemsResult>({ method: 'items', params }),
         annotations: async params => send<AnnotationsResult>({ method: 'annotations', params }),
     }

--- a/lib/client/src/providerClient/transport/module.ts
+++ b/lib/client/src/providerClient/transport/module.ts
@@ -100,6 +100,7 @@ function providerFromModule(providerModule: ProviderModule): Provider {
 function lazyProvider(provider: Promise<Provider>): ProviderTransport {
     return {
         capabilities: async (params, settings) => (await provider).capabilities(params, settings),
+        mentions: async (params, settings) => (await provider).mentions?.(params, settings) ?? [],
         items: async (params, settings) => (await provider).items?.(params, settings) ?? [],
         annotations: async (params, settings) => (await provider).annotations?.(params, settings) ?? [],
         dispose: () => {

--- a/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
+++ b/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').OpenCtxProvider} */
 module.exports = {
-    capabilities: () => ({ selector: [{ path: 'foo' }] }),
+    capabilities: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
 }

--- a/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').Provider} */
 module.exports = {
-  capabilities: () => ({ selector: [{ path: 'foo' }] }),
+    capabilities: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
 }

--- a/lib/client/src/providerClient/transport/testdata/emoji.js
+++ b/lib/client/src/providerClient/transport/testdata/emoji.js
@@ -1,5 +1,5 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-  capabilities: () => ({ selector: [{ path: 'foo' }] }),
+    capabilities: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
 }
 // ✨

--- a/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
+++ b/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    capabilities: () => ({ selector: [{ path: 'foo' }] }),
+    capabilities: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.js
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-  capabilities: () => ({ selector: [{ path: 'foo' }] }),
+    capabilities: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.ts
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.ts
@@ -1,7 +1,7 @@
 import type { Provider } from '@openctx/provider'
 
 const provider: Provider = {
-    capabilities: () => ({ selector: [{ path: 'foo' }] }),
+    capabilities: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
     annotations: () => [],
 }
 

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -153,7 +153,7 @@
       "required": [],
       "properties": {
         "message": {
-          "description": "A search query that is interpreted by providers to filter the items in the result set.",
+          "description": "A message that is interpreted by providers to return relevant items.",
           "type": "string"
         },
         "mention": {
@@ -171,7 +171,7 @@
       "tsType": "Item[]"
     },
     "Mention": {
-      "description": "TODO: move this to openctx.schema.json and figure out why it is not getting imported in the protocol-schema.ts",
+      "description": "A mention contains presentation information relevant to a resource.",
       "type": "object",
       "additionalProperties": false,
       "required": ["title", "uri"],

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -174,7 +174,7 @@
       "description": "TODO: move this to openctx.schema.json and figure out why it is not getting imported in the protocol-schema.ts",
       "type": "object",
       "additionalProperties": false,
-      "required": ["title", "url"],
+      "required": ["title", "uri"],
       "properties": {
         "title": {
           "description": "A descriptive title.",

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -24,6 +24,15 @@
       "$ref": "#/definitions/CapabilitiesResult"
     },
     {
+      "$ref": "#/definitions/Mention"
+    },
+    {
+      "$ref": "#/definitions/MentionsParams"
+    },
+    {
+      "$ref": "#/definitions/MentionsResult"
+    },
+    {
       "$ref": "#/definitions/ItemsParams"
     },
     {
@@ -99,6 +108,7 @@
     "CapabilitiesResult": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["meta"],
       "properties": {
         "selector": {
           "description": "Selects the scope in which this provider should be called.\n\nAt least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.",
@@ -119,10 +129,70 @@
               }
             }
           }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "description": "The name of the provider.",
+              "type": "string"
+            },
+            "description": {
+              "description": "A description of the provider.",
+              "type": "string"
+            }
+          }
         }
       }
     },
     "ItemsParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [],
+      "properties": {
+        "message": {
+          "description": "A search query that is interpreted by providers to filter the items in the result set.",
+          "type": "string"
+        },
+        "mention": {
+          "type": "object",
+          "description": "A mention interpreted by providers to return items for the specified mention.",
+          "tsType": "Mention"
+        }
+      }
+    },
+    "ItemsResult": {
+      "type": "array",
+      "items": {
+        "$ref": "../../schema/src/openctx.schema.json#/definitions/Item"
+      },
+      "tsType": "Item[]"
+    },
+    "Mention": {
+      "description": "TODO: move this to openctx.schema.json and figure out why it is not getting imported in the protocol-schema.ts",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "url"],
+      "properties": {
+        "title": {
+          "description": "A descriptive title.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "A URI for the mention item.",
+          "type": "string",
+          "format": "uri"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": []
+        }
+      }
+    },
+    "MentionsParams": {
       "type": "object",
       "additionalProperties": false,
       "required": [],
@@ -133,12 +203,12 @@
         }
       }
     },
-    "ItemsResult": {
+    "MentionsResult": {
       "type": "array",
       "items": {
-        "$ref": "../../schema/src/openctx.schema.json#/definitions/Item"
+        "$ref": "#/definitions/Mention"
       },
-      "tsType": "Item[]"
+      "tsType": "Mention[]"
     },
     "AnnotationsParams": {
       "type": "object",

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -9,11 +9,15 @@ export type Protocol =
     | ProviderSettings
     | CapabilitiesParams
     | CapabilitiesResult
+    | Mention
+    | MentionsParams
+    | MentionsResult
     | ItemsParams
     | ItemsResult
     | AnnotationsParams
     | AnnotationsResult
 export type CapabilitiesParams = Record<string, never>
+export type MentionsResult = Mention[]
 export type ItemsResult = Item[]
 export type AnnotationsResult = Annotation[]
 
@@ -44,6 +48,16 @@ export interface CapabilitiesResult {
      * At least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.
      */
     selector?: Selector[]
+    meta: {
+        /**
+         * The name of the provider.
+         */
+        name: string
+        /**
+         * A description of the provider.
+         */
+        description?: string
+    }
 }
 /**
  * Defines a scope in which a provider is called.
@@ -62,11 +76,37 @@ export interface Selector {
      */
     contentContains?: string
 }
-export interface ItemsParams {
+/**
+ * TODO: move this to openctx.schema.json and figure out why it is not getting imported in the protocol-schema.ts
+ */
+export interface Mention {
+    /**
+     * A descriptive title.
+     */
+    title: string
+    /**
+     * A URI for the mention item.
+     */
+    uri?: string
+    data?: {
+        [k: string]: unknown | undefined
+    }
+}
+export interface MentionsParams {
     /**
      * A search query that is interpreted by providers to filter the items in the result set.
      */
     query?: string
+}
+export interface ItemsParams {
+    /**
+     * A search query that is interpreted by providers to filter the items in the result set.
+     */
+    message?: string
+    /**
+     * A mention interpreted by providers to return items for the specified mention.
+     */
+    mention?: Mention
 }
 export interface AnnotationsParams {
     /**

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -100,7 +100,7 @@ export interface MentionsParams {
 }
 export interface ItemsParams {
     /**
-     * A message that is interpreted by providers to return relevant items.
+     * A message that can be interpreted by providers to return relevant items.
      */
     message?: string
     /**

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -87,7 +87,7 @@ export interface Mention {
     /**
      * A URI for the mention item.
      */
-    uri?: string
+    uri: string
     data?: {
         [k: string]: unknown | undefined
     }

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -77,7 +77,7 @@ export interface Selector {
     contentContains?: string
 }
 /**
- * TODO: move this to openctx.schema.json and figure out why it is not getting imported in the protocol-schema.ts
+ * A mention contains presentation information relevant to a resource.
  */
 export interface Mention {
     /**
@@ -100,7 +100,7 @@ export interface MentionsParams {
 }
 export interface ItemsParams {
     /**
-     * A search query that is interpreted by providers to filter the items in the result set.
+     * A message that is interpreted by providers to return relevant items.
      */
     message?: string
     /**

--- a/lib/provider/src/provider.ts
+++ b/lib/provider/src/provider.ts
@@ -5,6 +5,8 @@ import type {
     CapabilitiesResult,
     ItemsParams,
     ItemsResult,
+    MentionsParams,
+    MentionsResult,
     ProviderSettings,
 } from '@openctx/protocol'
 
@@ -21,6 +23,8 @@ export interface Provider<S extends {} = ProviderSettings> {
         params: CapabilitiesParams,
         settings: S
     ): CapabilitiesResult | Promise<CapabilitiesResult>
+
+    mentions?(params: MentionsParams, settings: S): MentionsResult | Promise<MentionsResult>
 
     /**
      * Returns OpenCtx items.

--- a/provider/google-docs/index.test.ts
+++ b/provider/google-docs/index.test.ts
@@ -5,6 +5,6 @@ describe('googleDocs', () => {
     const SETTINGS: Settings = {}
 
     test('capabilities', async () => {
-        expect(await googleDocs.capabilities({}, SETTINGS)).toEqual({})
+        expect(await googleDocs.capabilities({}, SETTINGS)).toEqual({ meta: { name: 'Google Docs' } })
     })
 })

--- a/provider/google-docs/index.ts
+++ b/provider/google-docs/index.ts
@@ -23,7 +23,7 @@ export type Settings = {
  */
 const googleDocs: Provider<Settings> = {
     capabilities(): CapabilitiesResult {
-        return {}
+        return { meta: { name: 'Google Docs' } }
     },
 
     async items(params: ItemsParams, settingsInput: Settings): Promise<ItemsResult> {
@@ -38,7 +38,7 @@ const googleDocs: Provider<Settings> = {
         const docsAPI = googleDocsAPI({ version: 'v1', auth: oauth2Client })
         const driveAPI = googleDriveAPI({ version: 'v3', auth: oauth2Client })
 
-        const quotedQuery = JSON.stringify(params.query)
+        const quotedQuery = JSON.stringify(params.message)
         const files = await driveAPI.files.list({
             q: `(name contains ${quotedQuery} or fullText contains ${quotedQuery}) and mimeType = 'application/vnd.google-apps.document'`,
             spaces: 'drive',

--- a/provider/hello-world/index.test.ts
+++ b/provider/hello-world/index.test.ts
@@ -4,7 +4,9 @@ import helloWorld from './index'
 
 describe('helloWorld', () => {
     test('capabilities', () =>
-        expect(helloWorld.capabilities({}, {})).toStrictEqual<CapabilitiesResult>({}))
+        expect(helloWorld.capabilities({}, {})).toStrictEqual<CapabilitiesResult>({
+            meta: { name: '✨ Hello World!' },
+        }))
 
     test('annotations', () =>
         expect(

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -16,7 +16,7 @@ import type {
  */
 const helloWorld: Provider = {
     capabilities(params: CapabilitiesParams, settings: ProviderSettings): CapabilitiesResult {
-        return {}
+        return { meta: { name: '✨ Hello World!' } }
     },
 
     items(params: ItemsParams, settings: ProviderSettings): ItemsResult {

--- a/provider/links/index.test.ts
+++ b/provider/links/index.test.ts
@@ -25,6 +25,7 @@ describe('links', () => {
     test('capabilities', async () => {
         expect(await links.capabilities({}, SETTINGS)).toStrictEqual<CapabilitiesResult>({
             selector: [{ path: '**/*.ts' }, { path: '**/*.go' }],
+            meta: { name: 'Links' },
         })
     })
 

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -65,7 +65,7 @@ interface LinkPattern {
  */
 const links: Provider<Settings> = {
     capabilities(_params: CapabilitiesParams, settings: Settings): CapabilitiesResult {
-        return { selector: settings.links?.map(({ path }) => ({ path })) || [] }
+        return { selector: settings.links?.map(({ path }) => ({ path })) || [], meta: { name: 'Links' } }
     },
 
     items(params: ItemsParams, settings: Settings): ItemsResult {

--- a/provider/prometheus/index.test.ts
+++ b/provider/prometheus/index.test.ts
@@ -16,6 +16,7 @@ describe('prometheus', () => {
     test('capabilities', async () => {
         expect(await prometheus.capabilities({}, SETTINGS)).toStrictEqual<CapabilitiesResult>({
             selector: [{ path: '**/*.go' }],
+            meta: { name: 'Prometheus' },
         })
     })
 

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -58,7 +58,10 @@ interface MetricRegistrationPattern {
  */
 const prometheus: Provider<Settings> = {
     capabilities(_params: CapabilitiesParams, settings: Settings): CapabilitiesResult {
-        return { selector: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [] }
+        return {
+            selector: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [],
+            meta: { name: 'Prometheus' },
+        }
     },
 
     annotations(params: AnnotationsParams, settings: Settings): AnnotationsResult {

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -32,13 +32,14 @@ export interface Settings {
 const storybook: Provider<Settings> = {
     capabilities(_params: CapabilitiesParams, settings: Settings): CapabilitiesResult {
         if (!settings.storybookUrl) {
-            return {}
+            return { meta: { name: 'Storybook' } }
         }
         return {
             selector: [
                 { path: '**/*.story.(t|j)s?(x)' },
                 { path: '**/*.(t|j)s(x)', contentContains: 'react' },
             ],
+            meta: { name: 'Storybook' },
         }
     },
 

--- a/provider/url-fetcher/index.ts
+++ b/provider/url-fetcher/index.ts
@@ -52,7 +52,7 @@ async function fetchItem(params: ItemsParams, timeoutMs?: number): Promise<Items
         return []
     }
     try {
-        const content = await fetchContentForURLContextItem(url.toString(), timeoutSignal(timeoutMs))
+        const content = await fetchContentForURLContextItem(url, timeoutSignal(timeoutMs))
 
         if (content === null) {
             return []
@@ -76,7 +76,7 @@ async function fetchContentForURLContextItem(
     signal?: AbortSignal
 ): Promise<string | null> {
     const url = new URL(urlStr)
-    if (url.protocol !== 'http' && url.protocol !== 'https') {
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         return null
     }
     if (!/(localhost|\.\w{2,})$/.test(url.hostname)) {


### PR DESCRIPTION
- Adds `mentions` feature to the Provider interface.
- Makes OpenCtx client automatically assign `provider` to every return type from the providers. 
- Adds `providerUri` filter arguments to the OpenCtx client methods so that the consumer can request capabilities, mentions and items from a particular provider. 
- Adds `meta` field to the `CapabilitiesResult`, providing the provider name. 
- Updates the CLI to support mentions, capabilities, providerUri arg and more.

Test plan

Same as: https://github.com/sourcegraph/openctx/pull/48