### PR TITLE
provider: sourcegraph search provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,16 @@ importers:
         specifier: workspace:*
         version: link:../../lib/provider
 
+  provider/sourcegraph-search:
+    dependencies:
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+    devDependencies:
+      esbuild:
+        specifier: ^0.19.11
+        version: 0.19.12
+
   provider/storybook:
     dependencies:
       '@openctx/provider':

--- a/provider/sourcegraph-search/README.md
+++ b/provider/sourcegraph-search/README.md
@@ -1,0 +1,25 @@
+# Sourcegraph Search context provider for OpenCtx
+
+This is a context provider for [OpenCtx](https://openctx.org) that provides
+Sourcegraph search results as context via the mention and items APIs.
+
+## Usage
+
+Add the following to your settings in any OpenCtx client:
+
+```json
+"openctx.providers": {
+    // ...other providers...
+    "https://openctx.org/npm/@openctx/sourcegraph-search": true
+},
+```
+
+## Configuration
+
+This sample provider is not configurable.
+
+## Development
+
+- [Source code](https://sourcegraph.com/github.com/sourcegraph/openctx/-/tree/provider/sourcegraph-search)
+- [Docs](https://openctx.org/docs/providers/sourcegraph-search)
+- License: Apache 2.0

--- a/provider/sourcegraph-search/graphql.ts
+++ b/provider/sourcegraph-search/graphql.ts
@@ -1,0 +1,34 @@
+export class SourcegraphGraphQLAPIClient {
+    public get endpoint(): string {
+        return 'https://sourcegraph.com'
+    }
+
+    public async fetchSourcegraphAPI<T>(
+        query: string,
+        variables: Record<string, any> = {}
+    ): Promise<T | Error> {
+        const headers = new Headers()
+        headers.set('Content-Type', 'application/json; charset=utf-8')
+        headers.set('User-Agent', 'openctx-sourcegraph-search / 0.0.1')
+
+        const queryName = query.match(/^\s*(?:query|mutation)\s+(\w+)/m)?.[1] ?? 'unknown'
+        const url = this.endpoint + '/.api/graphql?' + queryName
+
+        return fetch(url, {
+            method: 'POST',
+            body: JSON.stringify({ query, variables }),
+            headers,
+        })
+            .then(verifyResponseCode)
+            .then(response => response.json() as T)
+            .catch(error => new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`))
+    }
+}
+
+async function verifyResponseCode(response: Response): Promise<Response> {
+    if (!response.ok) {
+        const body = await response.text()
+        throw new Error(`HTTP status code ${response.status}${body ? `: ${body}` : ''}`)
+    }
+    return response
+}

--- a/provider/sourcegraph-search/index.ts
+++ b/provider/sourcegraph-search/index.ts
@@ -1,0 +1,127 @@
+import type {
+    AnnotationsParams,
+    AnnotationsResult,
+    CapabilitiesParams,
+    CapabilitiesResult,
+    ItemsParams,
+    ItemsResult,
+    MentionsParams,
+    MentionsResult,
+    Provider,
+    ProviderSettings,
+} from '@openctx/provider'
+import { SourcegraphGraphQLAPIClient } from './graphql'
+import { isError, searchForFileChunks } from './search'
+
+const graphqlClient = new SourcegraphGraphQLAPIClient()
+
+/** Used to prefix context queries to indicate a sourcegraph search */
+const QUERY_PREFIXES = ['?', 'src:']
+
+/** We always limit our searches to files and a conservatively sized result set */
+const SEARCH_QUERY_CONST = 'type:file count:10'
+
+const sourcegraphSearch: Provider = {
+    capabilities(params: CapabilitiesParams, settings: ProviderSettings): CapabilitiesResult {
+        return {
+            // empty since we don't provide any annotations.
+            selector: [],
+            meta: {
+                name: 'Sourcegraph Search',
+            },
+        }
+    },
+
+    async mentions(params: MentionsParams): Promise<MentionsResult> {
+        if (!params.query) {
+            return []
+        }
+
+        const query = searchQueryFromMentionQuery(params.query)
+        if (!query) {
+            return []
+        }
+
+        const url = `${graphqlClient.endpoint}/search?q=${encodeURIComponent(
+            query.sourcegraphQuery
+        )}&patternType=literal`
+
+        return [
+            {
+                title: query.sourcegraphQuery,
+                uri: url,
+            },
+        ]
+    },
+
+    async items(params: ItemsParams, settings: ProviderSettings): Promise<ItemsResult> {
+        if (!params.mention?.uri) {
+            return []
+        }
+
+        const query = searchQueryFromURL(graphqlClient.endpoint, params.mention?.uri)
+        if (!query) {
+            return []
+        }
+
+        const chunks = await searchForFileChunks(graphqlClient, query.sourcegraphQuery)
+        if (isError(chunks)) {
+            throw chunks
+        }
+
+        return chunks.map(chunk => {
+            return {
+                title: `${chunk.repoName} ${chunk.path}:${chunk.lineRange}`,
+                uri: chunk.uri,
+                ui: {
+                    hover: { text: `From Sourcegraph query ${query.userInput}` },
+                },
+                ai: {
+                    content: chunk.content,
+                },
+            }
+        })
+    },
+
+    annotations(params: AnnotationsParams, settings: ProviderSettings): AnnotationsResult {
+        return []
+    },
+}
+
+interface SearchQuery {
+    userInput: string
+    sourcegraphQuery: string
+}
+
+function searchQueryFromURL(endpoint: string, url: string): SearchQuery | undefined {
+    const parsedUrl = new URL(url)
+    const q = parsedUrl.searchParams.get('q')
+
+    if (!q || parsedUrl.hostname !== new URL(endpoint).hostname) {
+        return undefined
+    }
+
+    return {
+        userInput: trimPrefix(q, SEARCH_QUERY_CONST).trim(),
+        sourcegraphQuery: q,
+    }
+}
+
+function searchQueryFromMentionQuery(query: string): SearchQuery {
+    const userInput = trimFirstPrefix(query, QUERY_PREFIXES)
+    return {
+        userInput,
+        sourcegraphQuery: `${SEARCH_QUERY_CONST} ${userInput}`,
+    }
+}
+
+function trimFirstPrefix(s: string, prefixes: string[]): string {
+    const prefix = prefixes.find(prefix => s.startsWith(prefix)) ?? ''
+    return s.slice(prefix.length)
+}
+
+function trimPrefix(s: string, prefix: string): string {
+    return s.startsWith(prefix) ? s.slice(prefix.length) : s
+}
+
+export default sourcegraphSearch

--- a/provider/sourcegraph-search/package.json
+++ b/provider/sourcegraph-search/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openctx/provider-sourcegraph-search",
+  "version": "0.0.1",
+  "description": "Sourcegraph Search (OpenCtx provider)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/openctx",
+    "directory": "provider/sourcegraph-search"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "index.ts",
+    "!**/*.test.*",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --build",
+    "test": "vitest",
+    "bundle": "esbuild --bundle --format=esm --outfile=dist/bundle.js index.ts"
+  },
+  "dependencies": {
+    "@openctx/provider": "workspace:*"
+  },
+  "devDependencies": {
+    "esbuild": "^0.19.11"
+  }
+}

--- a/provider/sourcegraph-search/search.ts
+++ b/provider/sourcegraph-search/search.ts
@@ -1,0 +1,124 @@
+interface GraphQLClient {
+    endpoint: string
+    fetchSourcegraphAPI<T>(query: string, variables: Record<string, any>): Promise<T | Error>
+}
+
+interface Chunk {
+    uri: string
+    path: string
+    content: string
+    repoName: string
+    /** A 1-based string like 119 (one line) or 119-121 (multi-line). */
+    lineRange: string
+}
+
+export async function searchForFileChunks(
+    graphqlClient: GraphQLClient,
+    query: string
+): Promise<Chunk[] | Error> {
+    const results = await graphqlClient
+        .fetchSourcegraphAPI<APIResponse<SearchResponse>>(SEARCH_QUERY, {
+            query,
+        })
+        .then(response =>
+            extractDataOrError(response, data => {
+                return data.search.results.results.flatMap(result => {
+                    if (result.__typename !== 'FileMatch') {
+                        return []
+                    }
+                    const url = `${graphqlClient.endpoint.replace(/\/$/, '')}${result.file.url}`
+                    return result.chunkMatches.map(chunkMatch => {
+                        const lineRange = chunkMatchContentToLineRange(
+                            chunkMatch.content,
+                            chunkMatch.contentStart.line
+                        )
+                        return {
+                            uri: `${url}?L${lineRange}`,
+                            path: result.file.path,
+                            repoName: result.repository.name,
+                            content: chunkMatch.content,
+                            lineRange,
+                        } satisfies Chunk
+                    })
+                })
+            })
+        )
+    return results
+}
+
+function chunkMatchContentToLineRange(content: string, startLine: number): string {
+    // chunk match API is zero based
+    const start = startLine + 1
+    // Remove trailing newline then split will be number of lines
+    const lineCount = content.replace(/\r?\n$/, '').split('\n').length
+    return lineCount <= 1 ? `${start}` : `${start}-${start + lineCount - 1}`
+}
+
+const SEARCH_QUERY = `
+query CodyMentionProviderSearch($query: String!) {
+  search(query: $query, version: V3, patternType: literal) {
+    results {
+      results {
+        __typename
+        ... on FileMatch {
+          repository {
+            name
+          }
+          file {
+            url
+            path
+          }
+          chunkMatches {
+            content
+            contentStart {
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+interface SearchResponse {
+    search: {
+        results: {
+            results: {
+                __typename: string
+                repository: {
+                    name: string
+                }
+                file: {
+                    url: string
+                    path: string
+                }
+                chunkMatches: {
+                    content: string
+                    contentStart: {
+                        line: number
+                    }
+                }[]
+            }[]
+        }
+    }
+}
+
+interface APIResponse<T> {
+    data?: T
+    errors?: { message: string; path?: string[] }[]
+}
+
+function extractDataOrError<T, R>(response: APIResponse<T> | Error, extract: (data: T) => R): R | Error {
+    if (isError(response)) {
+        return response
+    }
+    if (response.errors && response.errors.length > 0) {
+        return new Error(response.errors.map(({ message }) => message).join(', '))
+    }
+    if (!response.data) {
+        return new Error('response is missing data')
+    }
+    return extract(response.data)
+}
+
+export const isError = (value: unknown): value is Error => value instanceof Error

--- a/provider/sourcegraph-search/tsconfig.json
+++ b/provider/sourcegraph-search/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../.config/tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "rootDir": ".",
+    "outDir": "dist",
+    "lib": ["ESNext"],
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "vitest.config.ts"],
+  "references": [{ "path": "../../lib/provider" }],
+}

--- a/provider/sourcegraph-search/vitest.config.ts
+++ b/provider/sourcegraph-search/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})


### PR DESCRIPTION
This is an initial Sourcegraph search provider which does unauthenticated searches against sourcegraph.com.

Test Plan: See tests done in https://github.com/sourcegraph/openctx/pull/48
