### PR TITLE
protocol: rename capabilities to meta

### DIFF
--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -41,23 +41,21 @@ export interface ResponseError {
     message: string
     data?: unknown
 }
-export interface CapabilitiesResult {
+export interface MetaResult {
     /**
-     * Selects the scope in which this provider should be called.
+     * The name of the provider.
+     */
+    name: string
+    /**
+     * A description of the provider.
+     */
+    description?: string
+    /**
+     * Selects the scope in which this provider's annotations should be called.
      *
      * At least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.
      */
-    selector?: Selector[]
-    meta: {
-        /**
-         * The name of the provider.
-         */
-        name: string
-        /**
-         * A description of the provider.
-         */
-        description?: string
-    }
+    annotationsSelector?: Selector[]
 }
 /**
  * Defines a scope in which a provider is called.

--- a/lib/provider/src/provider.ts
+++ b/lib/provider/src/provider.ts
@@ -1,8 +1,6 @@
 import type {
     AnnotationsParams,
     AnnotationsResult,
-    CapabilitiesParams,
-    CapabilitiesResult,
     ItemsParams,
     ItemsResult,
     MentionsParams,
@@ -19,10 +17,7 @@ export interface Provider<S extends {} = ProviderSettings> {
     /**
      * Reports the capabilities of the provider.
      */
-    capabilities(
-        params: CapabilitiesParams,
-        settings: S
-    ): CapabilitiesResult | Promise<CapabilitiesResult>
+    meta(params: MetaParams, settings: S): MetaResult | Promise<MetaResult>
 
     mentions?(params: MentionsParams, settings: S): MentionsResult | Promise<MentionsResult>
 


### PR DESCRIPTION
> Note: this is a non-functional PR to just discuss what a better name is before doing all the grunt work. It can turn into a PR which does the grunt work once we are happy. 

Capabilities is a hangover from LSP inspiration. Lets pick a better and more succinct name. Unsure if meta is the best, please debate below.

Additionally renamed the selector field to annotationsSelector since the field name became confusing once items and mentions was introduced.