### PR TITLE
google docs provider uses mentions and items

### DIFF
--- a/provider/google-docs/README.md
+++ b/provider/google-docs/README.md
@@ -4,6 +4,8 @@ This is a context provider for [OpenCtx](https://openctx.org) that brings Google
 
 **Status:** experimental
 
+> NOTE: Currently only works in development mode due to javascript bundling issues.
+
 ## Configuration
 
 To create Google Drive/Docs API credentials:

--- a/provider/google-docs/index.test.ts
+++ b/provider/google-docs/index.test.ts
@@ -1,10 +1,32 @@
 import { describe, expect, test } from 'vitest'
-import googleDocs, { type Settings } from './index.js'
+import googleDocs, { parseDocumentIDFromURL, type Settings } from './index.js'
 
 describe('googleDocs', () => {
     const SETTINGS: Settings = {}
 
     test('meta', async () => {
         expect(await googleDocs.meta({}, SETTINGS)).toEqual({ name: 'Google Docs' })
+    })
+})
+
+describe('parseDocumentIDFromURL', () => {
+    test('parses valid Google Docs URL', () => {
+        const id = parseDocumentIDFromURL('https://docs.google.com/document/d/abc123_/edit')
+        expect(id).toBe('abc123_')
+    })
+
+    test('returns undefined for non-Google Docs URL', () => {
+        const id = parseDocumentIDFromURL('https://example.com/doc/123')
+        expect(id).toBeUndefined()
+    })
+
+    test('returns undefined for invalid Google Docs URL', () => {
+        const id = parseDocumentIDFromURL('https://docs.google.com/document')
+        expect(id).toBeUndefined()
+    })
+
+    test('returns undefined for Google Docs URL with invalid doc ID', () => {
+        const id = parseDocumentIDFromURL('https://docs.google.com/document/d/!nv@lid/')
+        expect(id).toBeUndefined()
     })
 })

--- a/provider/google-docs/package.json
+++ b/provider/google-docs/package.json
@@ -14,7 +14,7 @@
   "files": ["dist/bundle.js", "dist/index.d.ts"],
   "sideEffects": false,
   "scripts": {
-    "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --packages=external --format=esm --outfile=dist/bundle.js index.ts",
     "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
     "test": "vitest",
     "google-auth": "node --no-warnings=ExperimentalWarning --es-module-specifier-resolution=node --loader ts-node/esm/transpile-only auth.ts"


### PR DESCRIPTION
In the commit adding mentions we didn't update google docs to use mentions, isntead it incorrectly used the message field on ItemsParams.

This should make the provider a bit faster since we now only query the drive API at mentions time, then we hydrate the body at items time. We link between the two by extracting the document ID from the URL.