### PR TITLE
Add meta.features to the providers protocol

### DIFF
--- a/client/vscode/test/integration/api.test.cts
+++ b/client/vscode/test/integration/api.test.cts
@@ -61,7 +61,7 @@ suite('API', () => {
             })
 
             assert.deepEqual(
-                (await api.meta({})).map(cap => cap.meta.name),
+                (await api.meta({})).map(meta => meta.name),
                 ['foo']
             )
         })

--- a/lib/client/src/providerClient/testdata/provider.js
+++ b/lib/client/src/providerClient/testdata/provider.js
@@ -1,6 +1,6 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }] }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
     items: (_params, settings) => [
         {
             title: settings.myTitle,

--- a/lib/client/src/providerClient/transport/createTransport.test.ts
+++ b/lib/client/src/providerClient/transport/createTransport.test.ts
@@ -7,7 +7,7 @@ import { type ProviderTransport, createTransport } from './createTransport.js'
 async function expectProviderTransport(provider: ProviderTransport) {
     expect(await provider.meta({}, {})).toEqual<MetaResult>({
         selector: [{ path: 'foo' }],
-        meta: { name: 'foo' },
+        name: 'foo',
     })
 }
 
@@ -59,7 +59,7 @@ describe('createTransport', () => {
                 JSON.stringify({
                     result: {
                         selector: [{ path: 'foo' }],
-                        meta: { name: 'foo' },
+                        name: 'foo',
                     } satisfies MetaResult,
                 } satisfies ResponseMessage)
             )

--- a/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
+++ b/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').OpenCtxProvider} */
 module.exports = {
-    meta: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
 }

--- a/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').Provider} */
 module.exports = {
-    meta: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
 }

--- a/lib/client/src/providerClient/transport/testdata/emoji.js
+++ b/lib/client/src/providerClient/transport/testdata/emoji.js
@@ -1,5 +1,5 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
 }
 // ✨

--- a/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
+++ b/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.js
@@ -1,4 +1,4 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.ts
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.ts
@@ -1,7 +1,7 @@
 import type { Provider } from '@openctx/provider'
 
 const provider: Provider = {
-    meta: () => ({ selector: [{ path: 'foo' }], meta: { name: 'foo' } }),
+    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
     annotations: () => [],
 }
 

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -137,7 +137,7 @@
         "features": {
           "description": "The features supported by the provider.",
           "type": "object",
-          "additionalProperties": true,
+          "additionalProperties": false,
           "properties": {
             "mentions": {
               "description": "Whether the provider support mentions.",

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -108,7 +108,7 @@
     "MetaResult": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["meta"],
+      "required": ["name"],
       "properties": {
         "selector": {
           "description": "Selects the scope in which this provider should be called.\n\nAt least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.",
@@ -130,18 +130,18 @@
             }
           }
         },
-        "meta": {
+        "name": {
+          "description": "The name of the provider.",
+          "type": "string"
+        },
+        "features": {
+          "description": "The features supported by the provider.",
           "type": "object",
-          "additionalProperties": false,
-          "required": ["name"],
+          "additionalProperties": true,
           "properties": {
-            "name": {
-              "description": "The name of the provider.",
-              "type": "string"
-            },
-            "description": {
-              "description": "A description of the provider.",
-              "type": "string"
+            "mentions": {
+              "description": "Whether the provider support mentions.",
+              "type": "boolean"
             }
           }
         }

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -57,7 +57,7 @@ export interface MetaResult {
      */
     features?: {
         /**
-         * Whether the provider support mentions.
+         * Whether the provider supports mentions.
          */
         mentions?: boolean
         [k: string]: unknown | undefined

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -51,7 +51,7 @@ export interface MetaResult {
     /**
      * The name of the provider.
      */
-    name?: string
+    name: string
     /**
      * The features supported by the provider.
      */
@@ -60,7 +60,6 @@ export interface MetaResult {
          * Whether the provider supports mentions.
          */
         mentions?: boolean
-        [k: string]: unknown | undefined
     }
 }
 /**

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -48,15 +48,19 @@ export interface MetaResult {
      * At least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.
      */
     selector?: Selector[]
-    meta: {
+    /**
+     * The name of the provider.
+     */
+    name?: string
+    /**
+     * The features supported by the provider.
+     */
+    features?: {
         /**
-         * The name of the provider.
+         * Whether the provider support mentions.
          */
-        name: string
-        /**
-         * A description of the provider.
-         */
-        description?: string
+        mentions?: boolean
+        [k: string]: unknown | undefined
     }
 }
 /**

--- a/provider/google-docs/index.test.ts
+++ b/provider/google-docs/index.test.ts
@@ -5,6 +5,6 @@ describe('googleDocs', () => {
     const SETTINGS: Settings = {}
 
     test('meta', async () => {
-        expect(await googleDocs.meta({}, SETTINGS)).toEqual({ meta: { name: 'Google Docs' } })
+        expect(await googleDocs.meta({}, SETTINGS)).toEqual({ name: 'Google Docs' })
     })
 })

--- a/provider/google-docs/index.ts
+++ b/provider/google-docs/index.ts
@@ -23,7 +23,7 @@ export type Settings = {
  */
 const googleDocs: Provider<Settings> = {
     meta(): MetaResult {
-        return { meta: { name: 'Google Docs' } }
+        return { name: 'Google Docs' }
     },
 
     async items(params: ItemsParams, settingsInput: Settings): Promise<ItemsResult> {

--- a/provider/hello-world/index.test.ts
+++ b/provider/hello-world/index.test.ts
@@ -5,7 +5,7 @@ import helloWorld from './index.js'
 describe('helloWorld', () => {
     test('meta', () =>
         expect(helloWorld.meta({}, {})).toStrictEqual<MetaResult>({
-            meta: { name: '✨ Hello World!' },
+            name: '✨ Hello World!',
         }))
 
     test('annotations', () =>

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -16,7 +16,7 @@ import type {
  */
 const helloWorld: Provider = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
-        return { meta: { name: '✨ Hello World!' } }
+        return { name: '✨ Hello World!' }
     },
 
     items(params: ItemsParams, settings: ProviderSettings): ItemsResult {

--- a/provider/links/index.test.ts
+++ b/provider/links/index.test.ts
@@ -25,7 +25,7 @@ describe('links', () => {
     test('meta', async () => {
         expect(await links.meta({}, SETTINGS)).toStrictEqual<MetaResult>({
             selector: [{ path: '**/*.ts' }, { path: '**/*.go' }],
-            meta: { name: 'Links' },
+            name: 'Links',
         })
     })
 

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -65,7 +65,7 @@ interface LinkPattern {
  */
 const links: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
-        return { selector: settings.links?.map(({ path }) => ({ path })) || [], meta: { name: 'Links' } }
+        return { selector: settings.links?.map(({ path }) => ({ path })) || [], name: 'Links' }
     },
 
     items(params: ItemsParams, settings: Settings): ItemsResult {

--- a/provider/prometheus/index.test.ts
+++ b/provider/prometheus/index.test.ts
@@ -16,7 +16,7 @@ describe('prometheus', () => {
     test('meta', async () => {
         expect(await prometheus.meta({}, SETTINGS)).toStrictEqual<MetaResult>({
             selector: [{ path: '**/*.go' }],
-            meta: { name: 'Prometheus' },
+            name: 'Prometheus',
         })
     })
 

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -60,7 +60,7 @@ const prometheus: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
         return {
             selector: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [],
-            meta: { name: 'Prometheus' },
+            name: 'Prometheus',
         }
     },
 

--- a/provider/sourcegraph-search/index.ts
+++ b/provider/sourcegraph-search/index.ts
@@ -26,9 +26,8 @@ const sourcegraphSearch: Provider = {
         return {
             // empty since we don't provide any annotations.
             selector: [],
-            meta: {
-                name: 'Sourcegraph Search',
-            },
+            name: 'Sourcegraph Search',
+            features: { mentions: true },
         }
     },
 

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -32,14 +32,14 @@ export interface Settings {
 const storybook: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
         if (!settings.storybookUrl) {
-            return { meta: { name: 'Storybook' } }
+            return { name: 'Storybook' }
         }
         return {
             selector: [
                 { path: '**/*.story.(t|j)s?(x)' },
                 { path: '**/*.(t|j)s(x)', contentContains: 'react' },
             ],
-            meta: { name: 'Storybook' },
+            name: 'Storybook',
         }
     },
 

--- a/provider/url-fetcher/index.ts
+++ b/provider/url-fetcher/index.ts
@@ -18,7 +18,8 @@ const urlFetcher: Provider<UrlFetcherSettings> = {
         return {
             // empty since we don't provide any annotations.
             selector: [],
-            meta: { name: 'URLs' },
+            name: 'URLs',
+            features: { mentions: true },
         }
     },
 

--- a/provider/url-fetcher/index.ts
+++ b/provider/url-fetcher/index.ts
@@ -18,7 +18,7 @@ const urlFetcher: Provider<UrlFetcherSettings> = {
         return {
             // empty since we don't provide any annotations.
             selector: [],
-            name: 'URLs',
+            name: 'Web URLs',
             features: { mentions: true },
         }
     },


### PR DESCRIPTION
This PR updates the provider's protocol to implement `MetaResult` as follows. 

Before:
```
meta {
  selectors?: Selector[];
  meta: { name: string; }
}
```

After:
```
meta {
  selectors?: Selector[];
  name: string;
  features?: { mentions?: boolean; }
}
```