### PR TITLE
improve provider build/publish steps

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -17,8 +17,7 @@
   "files": ["dist/cli.mjs"],
   "scripts": {
     "openctx": "pnpm run --silent bundle && node --no-warnings=ExperimentalWarning --experimental-network-imports dist/cli.mjs",
-    "build": "tsc --build",
-    "bundle": "esbuild --log-level=error --platform=node --bundle --outdir=dist --format=esm --out-extension:.js=.mjs cli.mts",
+    "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --outdir=dist --format=esm --out-extension:.js=.mjs cli.mts",
     "prepublishOnly": "tsc --build --clean && pnpm run --silent build && pnpm run --silent bundle"
   },
   "dependencies": {

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -57,7 +57,7 @@ export interface MetaResult {
      */
     features?: {
         /**
-         * Whether the provider supports mentions.
+         * Whether the provider support mentions.
          */
         mentions?: boolean
     }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "url": "https://github.com/sourcegraph/openctx"
   },
   "engines": {
-    "node": "^20.10.0",
+    "node": ">=20.10.0",
     "pnpm": "^8.6.7"
   },
   "packageManager": "pnpm@8.12.1",
   "scripts": {
-    "build": "pnpm run --recursive prebuild && tsc --build && pnpm run --silent bundle",
-    "bundle": "pnpm run --recursive bundle",
+    "build": "pnpm run --recursive prebuild && tsc --build",
+    "bundle": "pnpm run --silent build && pnpm run --recursive bundle",
     "watch": "tsc --build --watch",
     "generate": "pnpm run --recursive generate",
     "check": "pnpm run -s biome && pnpm run -s check:css",
@@ -37,6 +37,7 @@
     "@types/semver": "^7.5.6",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^1.6.0",
+    "esbuild": "^0.21.3",
     "js-yaml": "^4.1.0",
     "semver": "^7.5.4",
     "storybook": "^7.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.6.0
         version: 1.6.0(vitest@1.6.0)
+      esbuild:
+        specifier: ^0.21.3
+        version: 0.21.3
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -537,10 +540,6 @@ importers:
       '@openctx/provider':
         specifier: workspace:*
         version: link:../../lib/provider
-    devDependencies:
-      esbuild:
-        specifier: ^0.19.11
-        version: 0.19.12
 
   provider/storybook:
     dependencies:
@@ -557,10 +556,6 @@ importers:
       '@openctx/provider':
         specifier: workspace:*
         version: link:../../lib/provider
-    devDependencies:
-      esbuild:
-        specifier: ^0.21.3
-        version: 0.21.3
 
   web:
     dependencies:

--- a/provider/google-docs/package.json
+++ b/provider/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-google-docs",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "description": "Google Docs context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {
@@ -9,17 +9,13 @@
     "directory": "provider/google-docs"
   },
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "index.ts",
-    "!**/*.test.*",
-    "README.md"
-  ],
+  "files": ["dist/bundle.js", "dist/index.d.ts"],
   "sideEffects": false,
   "scripts": {
-    "build": "tsc --build",
+    "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
     "test": "vitest",
     "google-auth": "node --no-warnings=ExperimentalWarning --es-module-specifier-resolution=node --loader ts-node/esm/transpile-only auth.ts"
   },

--- a/provider/hello-world/package.json
+++ b/provider/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-hello-world",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "Hello World (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/hello-world",
@@ -12,10 +12,14 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.ts", "!**/*.test.*", "README.md"],
+  "files": [
+    "dist/index.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",
+    "prepublishOnly": "tsc --build --clean && pnpm run --silent build",
     "test": "vitest"
   },
   "dependencies": {

--- a/provider/links/package.json
+++ b/provider/links/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-links",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "description": "Add links to your code based on configurable patterns (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/links",
@@ -12,10 +12,14 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.ts", "!**/*.test.*", "README.md"],
+  "files": [
+    "dist/index.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",
+    "prepublishOnly": "tsc --build --clean && npm run --silent build",
     "test": "vitest"
   },
   "dependencies": {

--- a/provider/prometheus/package.json
+++ b/provider/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-prometheus",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "Hover over a Prometheus metric to see what it's doing in prod (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/prometheus",
@@ -12,10 +12,14 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.ts", "!**/*.test.*", "README.md"],
+  "files": [
+    "dist/index.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",
+    "prepublishOnly": "tsc --build --clean && npm run --silent build",
     "test": "vitest"
   },
   "dependencies": {

--- a/provider/sourcegraph-search/package.json
+++ b/provider/sourcegraph-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-sourcegraph-search",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Sourcegraph Search (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/sourcegraph-search",
@@ -12,17 +12,17 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.ts", "!**/*.test.*", "README.md"],
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsc --build",
-    "bundle": "esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
     "test": "vitest"
   },
   "dependencies": {
     "@openctx/provider": "workspace:*"
-  },
-  "devDependencies": {
-    "esbuild": "^0.19.11"
   }
 }

--- a/provider/storybook/package.json
+++ b/provider/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-storybook",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "Add Storybook links and image previews to your code (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/storybook",
@@ -10,12 +10,13 @@
     "directory": "provider/storybook"
   },
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.ts", "!**/*.test.*", "README.md"],
+  "files": ["dist/bundle.js", "dist/index.d.ts"],
   "sideEffects": false,
   "scripts": {
-    "build": "tsc --build",
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
     "test": "vitest"
   },
   "dependencies": {

--- a/provider/web/package.json
+++ b/provider/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-web",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Use information from web pages (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/web",
@@ -12,17 +12,17 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.ts", "!**/*.test.*", "README.md"],
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsc --build",
-    "bundle": "esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
     "test": "vitest"
   },
   "dependencies": {
     "@openctx/provider": "workspace:*"
-  },
-  "devDependencies": {
-    "esbuild": "^0.21.3"
   }
 }

--- a/web/content/docs/creating-a-provider.mdx
+++ b/web/content/docs/creating-a-provider.mdx
@@ -21,15 +21,73 @@ For convenience, you can also just bundle and publish a `.js` file that implemen
 ```typescript
 import type {
   AnnotationsParams, AnnotationsResult,
+  MentionsParams, MentionsResult,
   MetaParams, MetaResult,
   ItemsParams, ItemsResult, Provider,
 } from '@openctx/provider'
 
 export default {
   meta(params: MetaParams): Promise<MetaResult> { /* ... */ }
+  mentions(params: MentionsParams): Promise<MentionsResult> { /*... */ }
   items(params: ItemsParams): Promise<ItemsResult> { /* ... */ }
   annotations(params: AnnotationsParams): Promise<AnnotationsResult> { /*... */ }
 } satisfies Provider
 ```
 
 Then use the URL (`file://` or `https://`) to that `.js` file. This way, you don't need to deploy a public HTTP server for the provider. See the [playground](/playground) for live examples.
+
+### Using providers published to npm
+
+For convenience, the URL `https://openctx.org/npm/PACKAGE` serves the contents of the named [npm](https://npmjs.com/) package's `main` file.
+
+For example, suppose you have an [npm package `@openctx/provider-hello-world`](https://npmjs.com/package/@openctx/provider-hello-world) published with the following `package.json`:
+
+```json
+{
+  "name": "@openctx/provider-hello-world",
+  "main": "index.js",
+  // ...
+}
+```
+
+You can configure that provider in an OpenCtx client like so:
+
+```json
+"openctx.providers": {
+    "https://openctx.org/npm/@openctx/provider-hello-world": true
+},
+```
+
+The package's `index.js` file is loaded and expected to have a single default export that satisfies the `Provider` interface.
+
+See the source code for the [Hello World provider](https://openctx.org/docs/providers/hello-world) for a full example.
+
+### Bundling provider packages
+
+The above example works for simple providers written in a single JavaScript file. For providers written in TypeScript or implemented across multiple source files, you need to bundle the provider to a single JavaScript file (ESM).
+
+Here's an example `package.json` for this slightly more complex provider:
+
+```
+{
+  "name": "@openctx/provider-web",
+  "type": "module",
+  "main": "dist/bundle.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/bundle.js", "dist/index.d.ts"],
+  "sideEffects": false,
+  "scripts": {
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle"
+  },
+  "dependencies": {
+    "@openctx/provider": "*"
+  },
+  "devDependencies": {
+    "esbuild": "*",
+    "typescript": "*"
+  }
+}
+```
+
+See the source code for the [web page context provider](https://openctx.org/docs/providers/web) for a full example.

--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -8,7 +8,7 @@ NODE_VERSION = "20.10.0"
 
 [[redirects]]
 from = "/npm/*"
-to = "https://esm.sh/v135/:splat/es2022/dist.bundle.js?bundle-deps"
+to = "https://unpkg.com/:splat"
 status = 301
 force = true
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm run -w -s build && vite build --mode production",
+    "build": "pnpm run -w -s bundle && vite build --mode production",
     "test": "vitest",
     "preview": "vite preview"
   },

--- a/web/pages/playground/data.ts
+++ b/web/pages/playground/data.ts
@@ -48,7 +48,7 @@ function providerBundleUrl(packageName: string, importUrl: string): string {
 
 const settings = {
     'openctx.providers': {
-        [providerBundleUrl('@openctx/provider-links@0.0.10', providerLinksUrl)]: {
+        [providerBundleUrl('@openctx/provider-links@0.0.12', providerLinksUrl)]: {
             links: [
                 {
                     title: 'Telemetry',
@@ -73,7 +73,7 @@ const settings = {
                 },
             ],
         } satisfies import('@openctx/provider-links').Settings,
-        [providerBundleUrl('@openctx/provider-prometheus@0.0.8', providerPrometheusUrl)]: {
+        [providerBundleUrl('@openctx/provider-prometheus@0.0.10', providerPrometheusUrl)]: {
             metricRegistrationPatterns: [
                 {
                     path: '**/*.ts?(x)',
@@ -83,7 +83,7 @@ const settings = {
                 },
             ],
         } satisfies import('@openctx/provider-prometheus').Settings,
-        [providerBundleUrl('@openctx/provider-storybook@0.0.8', providerStorybookUrl)]: {
+        [providerBundleUrl('@openctx/provider-storybook@0.0.10', providerStorybookUrl)]: {
             storybookUrl:
                 'https://daeeaa811098f52f15a110dbaf76b6c416191c3b--5f0f381c0e50750022dc6bf7.chromatic.com/', // this is a public URL because our storybooks are public
         } satisfies import('@openctx/provider-storybook').Settings,


### PR DESCRIPTION
- use unpkg instead of esm.sh
- standardize bundling build steps
- document how to build and publish a provider