### PR TITLE
client: use shorter tmpdir name for vscode

### DIFF
--- a/client/vscode/test/integration/main.cts
+++ b/client/vscode/test/integration/main.cts
@@ -23,8 +23,10 @@ async function main(): Promise<void> {
 
     let exitCode: number
 
-    // Ensure we're running in a clean VS Code user data dir.
-    const tmpDir = await mkdtemp(path.join(tmpdir(), 'openctx-vscode-integration-test-'))
+    // Ensure we're running in a clean VS Code user data dir. We use a short
+    // name to avoid "WARNING: IPC handle is longer than 103 chars, try a
+    // shorter --user-data-dir"
+    const tmpDir = await mkdtemp(path.join(tmpdir(), 'octxvstest-'))
     const tmpUserDataDir = path.join(tmpDir, 'userdata')
     const tmpWorkspaceDir = path.join(tmpDir, 'workspace')
     const tmpScratchDir = path.join(tmpDir, 'scratch')


### PR DESCRIPTION
The mac integration test was failing due to /tmp being actually under something that looks like
/var/folders/2f/8t5k6yr535sdw0s4glnpxrzm0000gn/T/ and vscode not being able to take links to the ipc socket that have path names longer than 103.

Test Plan: CI