### PR TITLE
sourcegraph-search: item should be URL field not URI

### DIFF
--- a/provider/sourcegraph-search/index.ts
+++ b/provider/sourcegraph-search/index.ts
@@ -1,6 +1,4 @@
 import type {
-    AnnotationsParams,
-    AnnotationsResult,
     ItemsParams,
     ItemsResult,
     MentionsParams,
@@ -71,7 +69,7 @@ const sourcegraphSearch: Provider = {
         return chunks.map(chunk => {
             return {
                 title: `${chunk.repoName} ${chunk.path}:${chunk.lineRange}`,
-                uri: chunk.uri,
+                url: chunk.url,
                 ui: {
                     hover: { text: `From Sourcegraph query ${query.userInput}` },
                 },
@@ -80,10 +78,6 @@ const sourcegraphSearch: Provider = {
                 },
             }
         })
-    },
-
-    annotations(params: AnnotationsParams, settings: ProviderSettings): AnnotationsResult {
-        return []
     },
 }
 

--- a/provider/sourcegraph-search/search.ts
+++ b/provider/sourcegraph-search/search.ts
@@ -4,7 +4,7 @@ interface GraphQLClient {
 }
 
 interface Chunk {
-    uri: string
+    url: string
     path: string
     content: string
     repoName: string
@@ -33,7 +33,7 @@ export async function searchForFileChunks(
                             chunkMatch.contentStart.line
                         )
                         return {
-                            uri: `${url}?L${lineRange}`,
+                            url: `${url}?L${lineRange}`,
                             path: result.file.path,
                             repoName: result.repository.name,
                             content: chunkMatch.content,


### PR DESCRIPTION
This was a bug. I do not know how to make typescript correctly assert we don't have extra fields.