### PR TITLE
provider: add initial Notion provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,15 @@ importers:
         specifier: workspace:*
         version: link:../../lib/provider
 
+  provider/notion:
+    dependencies:
+      '@notionhq/client':
+        specifier: ^2.2.15
+        version: 2.2.15
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+
   provider/prometheus:
     dependencies:
       '@openctx/provider':
@@ -3757,6 +3766,16 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.6.0
 
+  /@notionhq/client@2.2.15:
+    resolution: {integrity: sha512-XhdSY/4B1D34tSco/GION+23GMjaS9S2zszcqYkMHo8RcWInymF6L1x+Gk7EmHdrSxNFva2WM8orhC4BwQCwgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@types/node-fetch': 2.6.4
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -6165,7 +6184,6 @@ packages:
     dependencies:
       '@types/node': 20.11.20
       form-data: 3.0.0
-    dev: true
 
   /@types/node@18.19.3:
     resolution: {integrity: sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==}
@@ -6758,7 +6776,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /autoprefixer@10.4.16(postcss@8.4.35):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
@@ -7348,7 +7365,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
@@ -7772,7 +7788,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -8578,7 +8593,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: true
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}

--- a/provider/notion/README.md
+++ b/provider/notion/README.md
@@ -9,7 +9,7 @@ Add the following to your settings in any OpenCtx client:
 ```json
 "openctx.providers": {
     // ...other providers...
-    "https://openctx.org/npm/@openctx/notion": {
+    "https://openctx.org/npm/@openctx/provider-notion": {
         "auth": "<your notion bot access token>"
     }
 },

--- a/provider/notion/README.md
+++ b/provider/notion/README.md
@@ -1,0 +1,38 @@
+# Notion context provider for OpenCtx
+
+This is a context provider for [OpenCtx](https://openctx.org) that provides Notion results as context via the mentions and items APIs.
+
+## Usage
+
+Add the following to your settings in any OpenCtx client:
+
+```json
+"openctx.providers": {
+    // ...other providers...
+    "https://openctx.org/npm/@openctx/notion": {
+        "auth": "<your notion bot access token>"
+    }
+},
+```
+
+See https://developers.notion.com/docs/getting-started to get set up with a
+token for the Notion API.
+
+Remember to add your integration to a page such that it can search that page and
+all sub pages.
+
+## Configuration
+
+This provider configuration is a subset of the configuration for the NotionHQ JavaScript client:
+
+| Option      | Default value              | Type         | Description                                                                                                                                                  |
+| ----------- | -------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `auth`      | N/A                        | `string`     | Bearer token for authentication. Required.                                                                                                                   |
+| `logLevel`  | `warn`                     | `string`     | Verbosity of logs the instance will produce. Levels are debug, info, warn and error.                                                                         |
+| `timeoutMs` | `60_000`                   | `number`     | Number of milliseconds to wait before emitting timing out an API call to Notion.                                                                             |
+
+## Development
+
+- [Source code](https://sourcegraph.com/github.com/sourcegraph/openctx/-/tree/provider/notion)
+- [Docs](https://openctx.org/docs/providers/notion)
+- License: Apache 2.0

--- a/provider/notion/index.test.ts
+++ b/provider/notion/index.test.ts
@@ -1,0 +1,26 @@
+import { LogLevel } from '@notionhq/client'
+import { describe, expect, test } from 'vitest'
+import notion from './index.js'
+
+// You can override these via the environment to test against the actual API.
+const query = process.env.NOTION_QUERY ?? 'Get Started'
+const auth = process.env.NOTION_API_KEY ?? ''
+
+describe('notion', () => {
+    test.runIf(auth)('integration returns non-empty mentions result', async () => {
+        const settings = {
+            auth,
+            logLevel: LogLevel.DEBUG,
+        }
+
+        const mentions = await notion.mentions!({ query }, settings)
+        console.log(mentions)
+        expect(mentions).not.toStrictEqual([])
+
+        const mention = mentions[0]
+
+        const items = await notion.items!({ mention }, settings)
+        console.log(items)
+        expect(items).not.toStrictEqual([])
+    })
+})

--- a/provider/notion/index.ts
+++ b/provider/notion/index.ts
@@ -1,0 +1,118 @@
+import { Client, type LogLevel, isFullBlock, isFullPage, iteratePaginatedAPI } from '@notionhq/client'
+import type {
+    ItemsParams,
+    ItemsResult,
+    MentionsParams,
+    MentionsResult,
+    MetaParams,
+    MetaResult,
+    Provider,
+} from '@openctx/provider'
+import { getTextFromBlock } from './parse-text-from-any-block-type.js'
+
+/**
+ * Settings for the Notion OpenCtx provider.
+ *
+ * This is a subset of
+ * [ClientOptions](https://github.com/makenotion/notion-sdk-js/blob/v2.2.15/README.md#client-options)
+ * from notion-sdk-js (see Client constructor). Note that auth is required
+ * unlike the constructor.
+ */
+export type Settings = {
+    /**
+     * The token for communicating with the Notion API. See
+     * https://developers.notion.com/docs/getting-started to get set up.
+     */
+    auth: string
+    timeoutMs?: number
+    baseUrl?: string
+    logLevel?: LogLevel
+    notionVersion?: string
+}
+
+/**
+ * An [OpenCtx](https://openctx.org) provider that brings Notion context to code AI and
+ * editors.
+ */
+const notion: Provider<Settings> = {
+    meta(params: MetaParams, settings: Settings): MetaResult {
+        return {
+            // empty since we don't provide any annotations.
+            selector: [],
+            name: 'Notion',
+            features: { mentions: true },
+        }
+    },
+
+    async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {
+        if (!params.query) {
+            return []
+        }
+
+        const notion = new Client(settings)
+
+        // search API filters by page title
+        const response = await notion.search({
+            query: params.query,
+        })
+        const mentions: MentionsResult = []
+        for (const page of response.results) {
+            if (!isFullPage(page)) continue
+
+            // Technically the title should be at ".title", but the typescript
+            // definition doesn't say that. So we do the safer approach.
+            let title: string | undefined = undefined
+            for (const prop of Object.values(page.properties)) {
+                if (prop.type === 'title') {
+                    title = prop.title[0].plain_text
+                    break
+                }
+            }
+
+            if (!title) continue
+
+            mentions.push({
+                title,
+                uri: page.url,
+            })
+        }
+
+        return mentions
+    },
+
+    async items(params: ItemsParams, settings: Settings): Promise<ItemsResult> {
+        if (!params.mention) {
+            return []
+        }
+
+        const page_id = params.mention.uri.split('-').pop()
+        if (!page_id) {
+            return []
+        }
+
+        const notion = new Client(settings)
+        const blocks = []
+        for await (const block of iteratePaginatedAPI(notion.blocks.children.list, {
+            block_id: page_id,
+        })) {
+            if (!isFullBlock(block)) continue
+            blocks.push(getTextFromBlock(block))
+        }
+
+        if (!blocks) {
+            return []
+        }
+
+        return [
+            {
+                title: params.mention.title,
+                url: params.mention.uri,
+                ai: {
+                    content: blocks.join('\n'),
+                },
+            },
+        ]
+    },
+}
+
+export default notion

--- a/provider/notion/package.json
+++ b/provider/notion/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@openctx/provider-notion",
+  "version": "0.0.1",
+  "description": "Notion (OpenCtx provider)",
+  "license": "Apache-2.0",
+  "homepage": "https://openctx.org/docs/providers/notion",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/openctx",
+    "directory": "provider/notion"
+  },
+  "type": "module",
+  "main": "dist/bundle.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
+    "test": "vitest",
+    "emitJSDeclaration": "tsc -d --emitDeclarationOnly --allowJs parse-text-from-any-block-type.js"
+  },
+  "dependencies": {
+    "@notionhq/client": "^2.2.15",
+    "@openctx/provider": "workspace:*"
+  }
+}

--- a/provider/notion/parse-text-from-any-block-type.d.ts
+++ b/provider/notion/parse-text-from-any-block-type.d.ts
@@ -1,0 +1,1 @@
+export function getTextFromBlock(block: any): string

--- a/provider/notion/parse-text-from-any-block-type.js
+++ b/provider/notion/parse-text-from-any-block-type.js
@@ -1,0 +1,110 @@
+// Copy pasted from https://sourcegraph.com/github.com/makenotion/notion-sdk-js@7950edc034d3007b0612b80d3f424baef89746d9/-/blob/examples/parse-text-from-any-block-type/index.js
+// The typescript definitions in the SDK make it very hard to convert this code into typescript, so we just directly use js sample code they provide.
+//
+// Copyright 2021 Notion Labs, Inc. See MIT License at https://github.com/makenotion/notion-sdk-js/blob/v2.2.15/LICENSE
+
+// Take rich text array from a block child that supports rich text and return the plain text.
+// Note: All rich text objects include a plain_text field.
+const getPlainTextFromRichText = richText => {
+    return richText.map(t => t.plain_text).join('')
+    // Note: A page mention will return "Undefined" as the page name if the page has not been shared with the integration. See: https://developers.notion.com/reference/block#mention
+}
+
+// Use the source URL and optional caption from media blocks (file, video, etc.)
+const getMediaSourceText = block => {
+    let source
+    let caption
+
+    if (block[block.type].external) {
+        source = block[block.type].external.url
+    } else if (block[block.type].file) {
+        source = block[block.type].file.url
+    } else if (block[block.type].url) {
+        source = block[block.type].url
+    } else {
+        source = '[Missing case for media block types]: ' + block.type
+    }
+    // If there's a caption, return it with the source
+    if (block[block.type].caption.length) {
+        caption = getPlainTextFromRichText(block[block.type].caption)
+        return caption + ': ' + source
+    }
+    // If no caption, just return the source URL
+    return source
+}
+
+// Get the plain text from any block type supported by the public API.
+export const getTextFromBlock = block => {
+    let text
+
+    // Get rich text from blocks that support it
+    if (block[block.type].rich_text) {
+        // This will be an empty string if it's an empty line.
+        text = getPlainTextFromRichText(block[block.type].rich_text)
+    }
+    // Get text for block types that don't have rich text
+    else {
+        switch (block.type) {
+            case 'unsupported':
+                // The public API does not support all block types yet
+                text = '[Unsupported block type]'
+                break
+            case 'bookmark':
+                text = block.bookmark.url
+                break
+            case 'child_database':
+                text = block.child_database.title
+                // Use "Query a database" endpoint to get db rows: https://developers.notion.com/reference/post-database-query
+                // Use "Retrieve a database" endpoint to get additional properties: https://developers.notion.com/reference/retrieve-a-database
+                break
+            case 'child_page':
+                text = block.child_page.title
+                break
+            case 'embed':
+            case 'video':
+            case 'file':
+            case 'image':
+            case 'pdf':
+                text = getMediaSourceText(block)
+                break
+            case 'equation':
+                text = block.equation.expression
+                break
+            case 'link_preview':
+                text = block.link_preview.url
+                break
+            case 'synced_block':
+                // Provides ID for block it's synced with.
+                text = block.synced_block.synced_from
+                    ? 'This block is synced with a block with the following ID: ' +
+                      block.synced_block.synced_from[block.synced_block.synced_from.type]
+                    : 'Source sync block that another blocked is synced with.'
+                break
+            case 'table':
+                // Only contains table properties.
+                // Fetch children blocks for more details.
+                text = 'Table width: ' + block.table.table_width
+                break
+            case 'table_of_contents':
+                // Does not include text from ToC; just the color
+                text = 'ToC color: ' + block.table_of_contents.color
+                break
+            case 'breadcrumb':
+            case 'column_list':
+            case 'divider':
+                text = 'No text available'
+                break
+            default:
+                text = '[Needs case added]'
+                break
+        }
+    }
+    // Blocks with the has_children property will require fetching the child blocks. (Not included in this example.)
+    // e.g. nested bulleted lists
+    if (block.has_children) {
+        // For now, we'll just flag there are children blocks.
+        text = text + ' (Has children)'
+    }
+    // Includes block type for readability. Update formatting as needed.
+    return block.type + ': ' + text
+}

--- a/provider/notion/tsconfig.json
+++ b/provider/notion/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../.config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "lib": ["ESNext"],
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "vitest.config.ts"],
+  "references": [{ "path": "../../lib/provider" }],
+}

--- a/provider/notion/vitest.config.ts
+++ b/provider/notion/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/provider/sourcegraph-search/README.md
+++ b/provider/sourcegraph-search/README.md
@@ -9,7 +9,7 @@ Add the following to your settings in any OpenCtx client:
 ```json
 "openctx.providers": {
     // ...other providers...
-    "https://openctx.org/npm/@openctx/sourcegraph-search": true
+    "https://openctx.org/npm/@openctx/provider-sourcegraph-search": true
 },
 ```
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     { "path": "provider/google-docs" },
     { "path": "provider/hello-world" },
     { "path": "provider/links" },
+    { "path": "provider/notion" },
     { "path": "provider/prometheus" },
     { "path": "provider/sourcegraph-search" },
     { "path": "provider/storybook" },

--- a/web/content/docs/providers/notion.mdx
+++ b/web/content/docs/providers/notion.mdx
@@ -1,0 +1,8 @@
+export const info = {
+  title: 'Notion',
+  group: 'providers',
+}
+
+import Readme from '../../../../provider/notion/README.md'
+
+<Readme />


### PR DESCRIPTION
This provider implements mentions and items to help find Notion pages and then turn them into content for an AI.

Note: The SDK for notion has quite tricky to use type definitions. As such I copy pasted the example JavaScript code they use and kept it as is rather than converting to TypeScript.

Test Plan: I created a notion bot integration, added a few pages then tested it manually in cody and via the integration test. The integration test was very useful during development so will keep it.