### PR TITLE
notion: use list for configuration options in README

### DIFF
--- a/provider/notion/README.md
+++ b/provider/notion/README.md
@@ -25,11 +25,9 @@ all sub pages.
 
 This provider configuration is a subset of the configuration for the NotionHQ JavaScript client:
 
-| Option      | Default value              | Type         | Description                                                                                                                                                  |
-| ----------- | -------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `auth`      | N/A                        | `string`     | Bearer token for authentication. Required.                                                                                                                   |
-| `logLevel`  | `warn`                     | `string`     | Verbosity of logs the instance will produce. Levels are debug, info, warn and error.                                                                         |
-| `timeoutMs` | `60_000`                   | `number`     | Number of milliseconds to wait before emitting timing out an API call to Notion.                                                                             |
+- `auth` :: Bearer token for authentication. Required.
+- `logLevel` :: Verbosity of logs the client will produce. Levels are `"debug"`, `"info"`, `"warn"` (default) and `"error"`.
+- `timeoutMs` :: The number of milliseconds to wait before timing out an API call to Notion. Defaults to `60000`.
 
 ## Development
 

--- a/web/pages/index/+Page.tsx
+++ b/web/pages/index/+Page.tsx
@@ -57,6 +57,7 @@ const INTEGRATIONS: IntegrationItem[] = [
     { name: 'Monaco Editor', type: 'client', slug: 'monaco-editor' },
     { name: 'CodeMirror', type: 'client', slug: 'codemirror' },
     { name: 'Storybook', type: 'provider', slug: 'storybook' },
+    { name: 'Notion', type: 'provider', slug: 'notion' },
     { name: 'Prometheus', type: 'provider', slug: 'prometheus' },
     { name: 'Links', type: 'provider', slug: 'links' },
     { name: 'Sourcegraph search', type: 'provider', slug: 'sourcegraph-search' },


### PR DESCRIPTION
The open context site does not seem to support markdown tables.