### PR TITLE
Implement GitHub context provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,35 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
 
+  provider/github:
+    dependencies:
+      '@octokit/core':
+        specifier: 5.2.0
+        version: 5.2.0
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+      fast-xml-parser:
+        specifier: ^4.4.0
+        version: 4.4.0
+    devDependencies:
+      '@octokit/types':
+        specifier: ^13.5.0
+        version: 13.5.0
+
+  provider/github2:
+    dependencies:
+      '@octokit/core':
+        specifier: 5.2.0
+        version: 5.2.0
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+    devDependencies:
+      '@octokit/types':
+        specifier: ^13.5.0
+        version: 13.5.0
+
   provider/google-docs:
     dependencies:
       '@googleapis/docs':
@@ -3776,6 +3805,68 @@ packages:
       - encoding
     dev: false
 
+  /@octokit/auth-token@4.0.0:
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+    dev: false
+
+  /@octokit/core@5.2.0:
+    resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.0
+      '@octokit/request': 8.4.0
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 13.5.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/endpoint@9.0.5:
+    resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.5.0
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/graphql@7.1.0:
+    resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request': 8.4.0
+      '@octokit/types': 13.5.0
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/openapi-types@22.2.0:
+    resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
+
+  /@octokit/request-error@5.1.0:
+    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.5.0
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+
+  /@octokit/request@8.4.0:
+    resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/endpoint': 9.0.5
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 13.5.0
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/types@13.5.0:
+    resolution: {integrity: sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==}
+    dependencies:
+      '@octokit/openapi-types': 22.2.0
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -6887,6 +6978,10 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
+  /before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+    dev: false
+
   /better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
@@ -7802,6 +7897,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  /deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+    dev: false
+
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -8432,6 +8531,13 @@ packages:
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
+
+  /fast-xml-parser@4.4.0:
+    resolution: {integrity: sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
 
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -12822,6 +12928,10 @@ packages:
       js-tokens: 8.0.3
     dev: true
 
+  /strnum@1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
+
   /style-mod@4.1.0:
     resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
 
@@ -13498,6 +13608,10 @@ packages:
       '@types/unist': 3.0.2
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+    dev: false
+
+  /universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
     dev: false
 
   /universalify@1.0.0:

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -1,6 +1,6 @@
 # GitHub provider for OpenCtx
 
-This is a context provider for [OpenCtx](https://openctx.org) that fetches contents from web pages by URL for use as context.
+This is a context provider for [OpenCtx](https://openctx.org) that fetches pull requests and issues contents from GitHub.
 
 ## Usage
 

--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -1,0 +1,28 @@
+# GitHub provider for OpenCtx
+
+This is a context provider for [OpenCtx](https://openctx.org) that fetches contents from web pages by URL for use as context.
+
+## Usage
+
+Add the following to your settings in any OpenCtx client:
+
+```json
+"openctx.providers": {
+    // ...other providers...
+    "https://openctx.org/npm/@openctx/provider-github": {
+        // create an access token from here: https://github.com/settings/tokens/new?scopes=repo
+        "accessToken": "<your-access-token>",
+    }
+},
+```
+
+Then use the `@`-mention type **Github PRs & Issues** and search for issues or pull requests to include in context using the followining possible query examples:
+
+- issue:sourcegraph/cody/123
+- pr:sourcegraph/cody/456
+
+## Development
+
+- [Source code](https://sourcegraph.com/github.com/sourcegraph/openctx/-/tree/provider/github)
+- [Docs](https://openctx.org/docs/providers/github)
+- License: Apache 2.0

--- a/provider/github/client.ts
+++ b/provider/github/client.ts
@@ -1,0 +1,27 @@
+import { Octokit } from '@octokit/core'
+import type { Endpoints, RequestParameters } from '@octokit/types'
+
+export interface GithubClientConfig {
+    accessToken: string
+}
+
+export type GithubEndpoints = Endpoints
+
+export class GithubClient {
+    private octokit: Octokit
+
+    constructor(config: GithubClientConfig) {
+        this.octokit = new Octokit({ auth: config.accessToken })
+    }
+
+    async request<E extends keyof Endpoints>(
+        req: E,
+        params: E extends keyof Endpoints
+            ? Endpoints[E]['parameters'] & RequestParameters
+            : RequestParameters
+    ): Promise<Endpoints[E]['response']['data']> {
+        const response = await this.octokit.request(req, params)
+
+        return response?.data
+    }
+}

--- a/provider/github/index.ts
+++ b/provider/github/index.ts
@@ -93,7 +93,7 @@ function parseMentionUri(
         return null
     }
 
-    // "https://github.com/sourcegraph/openctx/pull/1234",
+    // example url: "https://github.com/sourcegraph/openctx/pull/1234",
     const [_, owner, repoName, kind, numberText] = url.pathname.split('/')
 
     if (!['issues', 'pull'].includes(kind)) {
@@ -112,8 +112,8 @@ function parseQuery(
     query = ''
 ): { owner?: string; repoName?: string; number?: number; kind: string } | null {
     /* supported query formats:
-     * - github:issue:1234
-     * - github:issue:sourcegraph/cody/1234
+     * - issue:1234
+     * - issue:sourcegraph/cody/1234
      */
     const [kind = '', id = ''] = query.split(':')
 

--- a/provider/github/index.ts
+++ b/provider/github/index.ts
@@ -1,0 +1,348 @@
+import type {
+    ItemsResult,
+    Mention,
+    MetaParams,
+    MetaResult,
+    Provider,
+    ProviderSettings,
+} from '@openctx/provider'
+import { XMLBuilder } from 'fast-xml-parser'
+import { GithubClient } from './client.js'
+
+type GithubProviderSettings = ProviderSettings & {
+    accessToken: string
+}
+
+const xmlBuilder = new XMLBuilder({
+    format: true,
+})
+
+const github: Provider<GithubProviderSettings> = {
+    meta(params: MetaParams, settings: ProviderSettings): MetaResult {
+        return { name: 'Github PRs & Issues', features: { mentions: true } }
+    },
+
+    async mentions({ query }, settings) {
+        if (!query) {
+            return []
+        }
+
+        const details = parseQuery(query)
+        if (!details) {
+            return []
+        }
+
+        const { owner, repoName, number, kind } = details
+        const githubClient = new GithubClient({ accessToken: settings.accessToken })
+
+        if (!owner || !repoName) {
+            return []
+        }
+
+        switch (kind) {
+            case 'issue':
+            case 'issues':
+                return getIssueMentions(githubClient, { owner, repoName, issueNumber: number })
+            case 'pr':
+            case 'pull':
+            case 'pulls':
+                return getPullRequestMentions(githubClient, { owner, repoName, pullNumber: number })
+            default:
+                return []
+        }
+    },
+
+    async items({ message, mention }, settings) {
+        console.log(mention)
+        if (!message && !mention?.uri) {
+            return []
+        }
+
+        const details = mention?.uri ? parseMentionUri(mention.uri) : parseQuery(message)
+        console.log(details)
+        if (!details) {
+            return []
+        }
+
+        const { owner, repoName, number, kind } = details
+        const githubClient = new GithubClient({ accessToken: settings.accessToken })
+
+        if (!owner || !repoName || !number) {
+            return []
+        }
+
+        switch (kind) {
+            case 'issue':
+            case 'issues':
+                return getIssueItems(githubClient, { owner, repoName, issueNumber: number })
+            case 'pr':
+            case 'pull':
+            case 'pulls':
+                return getPullRequestItems(githubClient, { owner, repoName, pullNumber: number })
+            default:
+                return []
+        }
+    },
+}
+
+function parseMentionUri(
+    uri: string
+): { owner?: string; repoName?: string; number?: number; kind: string } | null {
+    const url = new URL(uri)
+    if (url.hostname !== 'github.com') {
+        return null
+    }
+
+    // "https://github.com/sourcegraph/openctx/pull/1234",
+    const [_, owner, repoName, kind, numberText] = url.pathname.split('/')
+
+    if (!['issues', 'pull'].includes(kind)) {
+        return null
+    }
+
+    const number = numberText ? Number(numberText) : undefined
+    if (Number.isNaN(number)) {
+        return null
+    }
+
+    return { owner, repoName, number, kind }
+}
+
+function parseQuery(
+    query = ''
+): { owner?: string; repoName?: string; number?: number; kind: string } | null {
+    /* supported query formats:
+     * - github:issue:1234
+     * - github:issue:sourcegraph/cody/1234
+     */
+    const [kind = '', id = ''] = query.split(':')
+
+    if (!['issue', 'pr', 'pull'].includes(kind)) {
+        return null
+    }
+
+    const [owner, repoName, numberText] = id.split('/')
+
+    const number = numberText ? Number(numberText) : undefined
+    if (Number.isNaN(number)) {
+        return null
+    }
+
+    return { owner, repoName, number, kind }
+}
+
+async function getPullRequestMentions(
+    client: GithubClient,
+    params: {
+        owner: string
+        repoName: string
+        pullNumber?: number
+    }
+): Promise<Mention[]> {
+    try {
+        const pullRequests = params.pullNumber
+            ? [
+                  await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+                      owner: params.owner,
+                      repo: params.repoName,
+                      pull_number: params.pullNumber,
+                  }),
+              ]
+            : await client.request('GET /repos/{owner}/{repo}/pulls', {
+                  owner: params.owner,
+                  repo: params.repoName,
+                  per_page: 10,
+              })
+
+        return pullRequests.map(
+            pullRequest =>
+                ({
+                    uri: pullRequest.html_url,
+                    title: `#${pullRequest.number} ${pullRequest.title}`,
+                }) as Mention
+        )
+    } catch (error) {
+        return []
+    }
+}
+
+async function getIssueMentions(
+    client: GithubClient,
+    params: {
+        owner: string
+        repoName: string
+        issueNumber?: number
+    }
+): Promise<Mention[]> {
+    try {
+        const issues = params.issueNumber
+            ? [
+                  await client.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+                      owner: params.owner,
+                      repo: params.repoName,
+                      issue_number: params.issueNumber,
+                  }),
+              ]
+            : await client.request('GET /issues', {
+                  per_page: 10,
+                  pulls: false,
+              })
+
+        return issues.map(
+            issue =>
+                ({
+                    uri: issue.html_url,
+                    title: `#${issue.number} ${issue.title}`,
+                }) as Mention
+        )
+    } catch (error) {
+        return []
+    }
+}
+
+async function getPullRequestItems(
+    client: GithubClient,
+    details: { owner: string; repoName: string; pullNumber: number }
+): Promise<ItemsResult> {
+    try {
+        const pullRequest = await client.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+            owner: details.owner,
+            repo: details.repoName,
+            pull_number: details.pullNumber,
+        })
+
+        if (!pullRequest) {
+            return []
+        }
+
+        const [diff, comments, reviewComments] = await Promise.all([
+            client
+                .request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+                    owner: details.owner,
+                    repo: details.repoName,
+                    pull_number: details.pullNumber,
+                    mediaType: {
+                        format: 'diff',
+                    },
+                })
+                .catch(() => ''),
+            client
+                .request('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+                    owner: details.owner,
+                    repo: details.repoName,
+                    issue_number: details.pullNumber,
+                    per_page: 100,
+                })
+                .catch(() => []),
+            client
+                .request('GET /repos/{owner}/{repo}/pulls/{pull_number}/comments', {
+                    owner: details.owner,
+                    repo: details.repoName,
+                    pull_number: details.pullNumber,
+                    per_page: 100,
+                })
+                .catch(() => []),
+        ])
+
+        const content = xmlBuilder.build({
+            pull_request: {
+                url: pullRequest.html_url,
+                title: `#${pullRequest.number} ${pullRequest.title}`,
+                branch: pullRequest.head.ref,
+                author: pullRequest.user.login,
+                created_at: pullRequest.created_at,
+                merged: pullRequest.merged,
+                merged_at: pullRequest.merged_at,
+                mergeable: pullRequest.mergeable,
+                status: pullRequest.state,
+                body: pullRequest.body,
+                diff: diff,
+                comments: {
+                    comment: comments.map(comment => ({
+                        url: comment.html_url,
+                        author: comment.user?.login,
+                        body: comment.body,
+                        created_at: comment.created_at,
+                    })),
+                },
+                reviews: {
+                    review: reviewComments.map(review => ({
+                        url: review.html_url,
+                        author: review.user.login,
+                        body: review.body,
+                        created_at: review.created_at,
+                        file_path: review.path,
+                        diff: review.diff_hunk,
+                    })),
+                },
+            },
+        })
+
+        return [
+            {
+                url: pullRequest.html_url,
+                title: pullRequest.title,
+                ai: { content },
+            },
+        ]
+    } catch (error) {
+        return []
+    }
+}
+
+async function getIssueItems(
+    client: GithubClient,
+    details: { owner: string; repoName: string; issueNumber: number }
+): Promise<ItemsResult> {
+    try {
+        const issue = await client.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+            owner: details.owner,
+            repo: details.repoName,
+            issue_number: details.issueNumber,
+        })
+
+        if (!issue) {
+            return []
+        }
+
+        const comments = await client
+            .request('GET /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+                owner: details.owner,
+                repo: details.repoName,
+                issue_number: details.issueNumber,
+                per_page: 100,
+            })
+            .catch(() => [])
+
+        const content = xmlBuilder.build({
+            issue: {
+                url: issue.html_url,
+                title: `#${issue.number} ${issue.title}`,
+                author: issue.user?.login,
+                created_at: issue.created_at,
+                status: issue.state,
+                body: issue.body,
+                comments: {
+                    comment: comments.map(comment => ({
+                        url: comment.html_url,
+                        author: comment.user?.login,
+                        body: comment.body,
+                        created_at: comment.created_at,
+                    })),
+                },
+            },
+        })
+
+        return [
+            {
+                ai: { content },
+                url: issue.html_url,
+                title: issue.title,
+            },
+        ]
+    } catch {
+        return []
+    }
+}
+
+export default github

--- a/provider/github/package.json
+++ b/provider/github/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@openctx/provider-github",
+  "version": "0.0.1",
+  "description": "GitHub OpenCtx provider",
+  "license": "Apache-2.0",
+  "homepage": "https://openctx.org/docs/providers/github",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/openctx",
+    "directory": "provider/github"
+  },
+  "type": "module",
+  "main": "dist/bundle.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@octokit/core": "5.2.0",
+    "@openctx/provider": "workspace:*",
+    "fast-xml-parser": "^4.4.0"
+  },
+  "devDependencies": {
+    "@octokit/types": "^13.5.0"
+  }
+}

--- a/provider/github/tsconfig.json
+++ b/provider/github/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../.config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "lib": ["ESNext"],
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "vitest.config.ts"],
+  "references": [{ "path": "../../lib/provider" }],
+}

--- a/provider/github/vitest.config.ts
+++ b/provider/github/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})


### PR DESCRIPTION
This PR ports the GitHub context provider from Cody to OpenCtx. 

It provides context for both PRs and Issues. 

Current Limitation:
- The user has to start a query with `issues:` or `pr:` for it to work, and no separate UI will be shown to select issues/pr. 
- The user has to mention the repo name manually as `issue:sourcegraph/openctx/1234`, as no codebase info has been passed on to OpenCtx yet.

These 2 limitations will be address in follow up PRs. 