### PR TITLE
Implement Linear context provider 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
     "**/dist": true
   },
   "files.exclude": {
-    "**/dist": true,
     "**/.vscode-test": true,
     "**/.vscode-test-web": true,
     "coverage/": true,

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
 # OpenCtx documentation
 
 - [README.md](../README.md)
-- [Development](development/index.md)
+- [Development](./dev/index.md)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,6 +523,28 @@ importers:
         specifier: workspace:*
         version: link:../../lib/provider
 
+  provider/linear:
+    dependencies:
+      '@linear/sdk':
+        specifier: ^22.0.0
+        version: 22.0.0
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+      fast-xml-parser:
+        specifier: ^4.4.0
+        version: 4.4.0
+      open:
+        specifier: ^10.0.4
+        version: 10.1.0
+      server-destroy:
+        specifier: ^1.0.1
+        version: 1.0.1
+    devDependencies:
+      '@types/server-destroy':
+        specifier: ^1.0.3
+        version: 1.0.3
+
   provider/links:
     dependencies:
       '@openctx/provider':
@@ -3457,6 +3479,14 @@ packages:
       - supports-color
     dev: false
 
+  /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+    dev: false
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -3659,6 +3689,17 @@ packages:
     resolution: {integrity: sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==}
     dependencies:
       '@lezer/common': 1.1.1
+    dev: false
+
+  /@linear/sdk@22.0.0:
+    resolution: {integrity: sha512-sKzTb09w8jfWWuz1TIrVYx4J+9T8AQPxbR6xDlyX19h/bAfwATKf4EHfwJyMoRHDUTW0jhosrzBynpj0DfZuFA==}
+    engines: {node: '>=12.x', yarn: 1.x}
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      graphql: 15.8.0
+      isomorphic-unfetch: 3.1.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@mapbox/rehype-prism@0.9.0:
@@ -8433,6 +8474,13 @@ packages:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
 
+  /fast-xml-parser@4.4.0:
+    resolution: {integrity: sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
+
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -8906,7 +8954,7 @@ packages:
       google-auth-library: 9.9.0
       qs: 6.11.2
       url-template: 2.0.8
-      uuid: 9.0.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8920,6 +8968,11 @@ packages:
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
+
+  /graphql@15.8.0:
+    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
+    engines: {node: '>= 10.x'}
+    dev: false
 
   /gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
@@ -9645,6 +9698,15 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -12822,6 +12884,10 @@ packages:
       js-tokens: 8.0.3
     dev: true
 
+  /strnum@1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
+
   /style-mod@4.1.0:
     resolution: {integrity: sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==}
 
@@ -13396,6 +13462,10 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     requiresBuild: true
 
+  /unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
+    dev: false
+
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -13623,6 +13693,7 @@ packages:
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
+    dev: true
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}

--- a/provider/linear/.gitignore
+++ b/provider/linear/.gitignore
@@ -1,0 +1,2 @@
+linear_client_config.json
+linear_user_credentials.json

--- a/provider/linear/README.md
+++ b/provider/linear/README.md
@@ -1,0 +1,31 @@
+# Linear context provider for OpenCtx
+
+This is a context provider for [OpenCtx](https://openctx.org) that brings Linear context to code AI and editors. Only items, not annotations, are supported.
+
+**Status:** Experimental
+
+## Configuration
+
+To create Linear API credentials:
+
+1. [Create an OAuth2 application in Linear](https://linear.app/settings/api/applications/new).
+1. Save the client configuration JSON file (`linear_client_config.json`).
+1. Obtain an access token for your user account: run `LINEAR_OAUTH_CLIENT_FILE=path/to/linear_client_config.json pnpm auth` and continue in your web browser.
+1. The access token will be saved in a JSON file with a path printed to the console.
+
+Then use the following OpenCtx provider configuration:
+
+```json
+"openctx.providers": {
+    // ...other providers...
+    "https://openctx.org/npm/@openctx/provider-linear": {
+        "linearUserCredentialsPath": "path/to/access_token_file_printed.json",
+    }
+},
+```
+
+## Development
+
+- [Source code](https://sourcegraph.com/github.com/sourcegraph/openctx/-/tree/provider/linear)
+- [Docs](https://openctx.org/docs/providers/linear)
+- License: Apache 2.0

--- a/provider/linear/auth.ts
+++ b/provider/linear/auth.ts
@@ -58,6 +58,8 @@ export function createAccessToken(clientConfig?: LinearAuthClientConfig): Promis
                             client_secret: config.client_secret,
                         })
 
+                        // Exchange `code` for an access token
+                        // https://developers.linear.app/docs/oauth/authentication#id-4.-exchange-code-for-an-access-token
                         const tokenResponse = await fetch('https://api.linear.app/oauth/token', {
                             method: 'POST',
                             headers: {
@@ -78,7 +80,9 @@ export function createAccessToken(clientConfig?: LinearAuthClientConfig): Promis
                     reject(e)
                 }
             })
-            .listen(3000, () => {
+            .listen(port, () => {
+                //  Redirect user access requests to Linear
+                // https://developers.linear.app/docs/oauth/authentication#id-2.-redirect-user-access-requests-to-linear
                 const authorizeURL = new url.URL('https://linear.app/oauth/authorize')
                 authorizeURL.searchParams.set('response_type', 'code')
                 authorizeURL.searchParams.set('client_id', config.client_id)

--- a/provider/linear/auth.ts
+++ b/provider/linear/auth.ts
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync } from 'fs'
+import http from 'http'
+import path from 'path'
+import url, { fileURLToPath } from 'url'
+import { LinearClient } from '@linear/sdk'
+import open from 'open'
+import destroyer from 'server-destroy'
+
+export interface LinearAuthClientConfig {
+    client_id: string
+    client_secret: string
+    redirect_uris: string[]
+}
+
+export interface UserCredentials {
+    access_token: string
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const DEFAULT_USER_CREDENTIALS_PATH = path.resolve(__dirname, 'linear_user_credentials.json')
+const DEFAULT_CLIENT_CONFIG_PATH = path.join(__dirname, 'linear_client_config.json')
+
+const clientConfigPath = process.env.LINEAR_OAUTH_CLIENT_FILE || DEFAULT_CLIENT_CONFIG_PATH
+const userCredentialsPath = process.env.LINEAR_USER_CREDENTIALS_FILE || DEFAULT_USER_CREDENTIALS_PATH
+
+const port = process.env.PORT ? Number(process.env.PORT) : 3000
+const serverURL = `http://localhost:${port}`
+
+export const SCOPES = ['read']
+
+export function createAccessToken(clientConfig?: LinearAuthClientConfig): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const config =
+            clientConfig ||
+            (JSON.parse(readFileSync(clientConfigPath, 'utf8')) as LinearAuthClientConfig)
+
+        const [redirectUri] = config.redirect_uris
+
+        const server = http
+            .createServer(async (req, res) => {
+                try {
+                    if (req.url!.includes('/oauth2callback')) {
+                        const qs = new url.URL(req.url!, serverURL).searchParams
+                        const code = qs.get('code')
+                        if (!code) {
+                            throw new Error('code is not found!')
+                        }
+                        res.end('Authentication successful. Please return to the console.')
+                        server.destroy()
+
+                        const params = new URLSearchParams({
+                            code,
+                            grant_type: 'authorization_code',
+                            redirect_uri: redirectUri,
+                            client_id: config.client_id,
+                            client_secret: config.client_secret,
+                        })
+
+                        const tokenResponse = await fetch('https://api.linear.app/oauth/token', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                            },
+                            body: params.toString(),
+                        })
+
+                        const tokenData = await tokenResponse.json()
+
+                        if (tokenData.access_token) {
+                            resolve(tokenData.access_token)
+                        } else {
+                            reject(new Error('Failed to retrieve access token'))
+                        }
+                    }
+                } catch (e) {
+                    reject(e)
+                }
+            })
+            .listen(3000, () => {
+                const authorizeURL = new url.URL('https://linear.app/oauth/authorize')
+                authorizeURL.searchParams.set('response_type', 'code')
+                authorizeURL.searchParams.set('client_id', config.client_id)
+                authorizeURL.searchParams.set('redirect_uri', redirectUri)
+                authorizeURL.searchParams.set('scope', SCOPES.join(' '))
+
+                open(authorizeURL.toString(), { wait: false }).then(cp => cp.unref())
+            })
+        destroyer(server)
+    })
+}
+
+async function main() {
+    const accessToken = await createAccessToken()
+    const client = new LinearClient({ accessToken })
+    console.log(`Got access token: ${accessToken}`)
+
+    await client.issueSearch({ query: 'test' })
+    const userCredentials = JSON.stringify({ access_token: accessToken } satisfies UserCredentials)
+    writeFileSync(userCredentialsPath, userCredentials, {
+        encoding: 'utf8',
+    })
+
+    console.log(`Saved access token to ${userCredentialsPath}`)
+}
+
+main()

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'fs'
+import type {
+    ItemsParams,
+    ItemsResult,
+    MentionsParams,
+    MentionsResult,
+    MetaResult,
+    Provider,
+} from '@openctx/provider'
+
+import { LinearClient, type LinearClientOptions } from '@linear/sdk'
+import { XMLBuilder } from 'fast-xml-parser'
+import type { UserCredentials } from './auth.js'
+
+/** Settings for the Linear OpenCtx provider. */
+export type Settings = {
+    linearUserCredentialsPath?: string
+    linearClientOptions?: LinearClientOptions
+}
+
+const xmlBuilder = new XMLBuilder({ format: true })
+
+const linearIssues: Provider<Settings> = {
+    meta(): MetaResult {
+        return { name: 'Linear Issues', features: { mentions: true } }
+    },
+
+    async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {
+        if (!params.query) {
+            return []
+        }
+
+        const linearClient = getLinearClient(settingsInput)
+        const issues = await linearClient.issueSearch({ query: params.query, first: 25 })
+
+        return (issues.nodes ?? []).map(issue => ({
+            title: issue.title,
+            uri: issue.url,
+        }))
+    },
+
+    async items(params: ItemsParams, settingsInput: Settings): Promise<ItemsResult> {
+        if (!params.mention) {
+            return []
+        }
+
+        const issueId = parseIssueIDFromURL(params.mention.uri)
+        if (!issueId) {
+            return []
+        }
+
+        const linearClient = getLinearClient(settingsInput)
+
+        const issue = await linearClient.issue(issueId)
+        const comments = await issue.comments()
+
+        const content = xmlBuilder.build({
+            description: issue.description || '',
+            comments: comments.nodes.map(comment => comment.body).join('\n'),
+        })
+
+        return [
+            {
+                title: issue.title,
+                url: issue.url,
+                ai: {
+                    content,
+                },
+            },
+        ]
+    },
+}
+
+export default linearIssues
+
+function getLinearClient(settings: Settings): LinearClient {
+    if (settings.linearUserCredentialsPath) {
+        const userCredentialsString = readFileSync(settings.linearUserCredentialsPath, 'utf-8')
+        const userCredentials = JSON.parse(userCredentialsString) as Partial<UserCredentials>
+
+        if (!userCredentials.access_token) {
+            throw new Error(`access_token not found in ${settings.linearUserCredentialsPath}`)
+        }
+
+        return new LinearClient({ accessToken: userCredentials.access_token })
+    }
+
+    if (settings.linearClientOptions?.accessToken) {
+        return new LinearClient({ accessToken: settings.linearClientOptions?.accessToken })
+    }
+
+    if (settings.linearClientOptions?.apiKey) {
+        return new LinearClient({ apiKey: settings.linearClientOptions?.apiKey })
+    }
+
+    throw new Error(
+        'must provide a Linear user credentials path in the `linearUserCredentialsPath` settings field or a path to a JSON file in the LINEAR_USER_CREDENTIALS_FILE env var'
+    )
+}
+
+function parseIssueIDFromURL(urlStr: string): string | undefined {
+    const url = new URL(urlStr)
+    if (!url.hostname.endsWith('linear.app')) {
+        return undefined
+    }
+    const match = url.pathname.match(/\/issue\/([a-zA-Z0-9_-]+)/)
+    return match ? match[1] : undefined
+}

--- a/provider/linear/package.json
+++ b/provider/linear/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openctx/provider-linear",
+  "version": "0.0.1",
+  "description": "Linear context for code AI and editors (OpenCtx provider)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/openctx",
+    "directory": "provider/linear"
+  },
+  "type": "module",
+  "main": "dist/bundle.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist/bundle.js", "dist/index.d.ts"],
+  "sideEffects": false,
+  "scripts": {
+    "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
+    "test": "vitest",
+    "auth": "node --no-warnings=ExperimentalWarning --es-module-specifier-resolution=node --loader ts-node/esm/transpile-only auth.ts"
+  },
+  "dependencies": {
+    "@linear/sdk": "^22.0.0",
+    "@openctx/provider": "workspace:*",
+    "fast-xml-parser": "^4.4.0",
+    "open": "^10.0.4",
+    "server-destroy": "^1.0.1"
+  },
+  "devDependencies": {
+    "@types/server-destroy": "^1.0.3"
+  }
+}

--- a/provider/linear/tsconfig.json
+++ b/provider/linear/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../.config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "lib": ["ESNext"],
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "vitest.config.ts"],
+  "references": [{ "path": "../../lib/provider" }],
+}

--- a/provider/linear/vitest.config.ts
+++ b/provider/linear/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})


### PR DESCRIPTION
- Implements Linear context provider for OpenCtx, which allows to search for issues in Linear and use an issue title, description, and comments as AI content.
- Uses [@linear/sdk](https://developers.linear.app/docs/graphql/working-with-the-graphql-api#linear-sdk) to fetch issues
- Requires authorization in a Linear OAuth2 application or a personal API token

## Test plan

- Tested using [an OAuth2 application](https://linear.app/sourcegraph/settings/api/applications/a5c42ede-7768-45e7-bc39-e32b3208ceaf/edit) created in the Sourcegraph workspace