### PR TITLE
Update vscode-lib openctx client to access pre-imported providers

### DIFF
--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -7,6 +7,7 @@ import {
     type Range,
     createClient,
 } from '@openctx/client'
+import type { ImportedProviderConfiguration } from '@openctx/client/src/configuration.js'
 import {
     type Observable,
     type TapObserver,
@@ -58,11 +59,13 @@ export function createController({
     outputChannel,
     getAuthInfo,
     features,
+    providers,
 }: {
     secrets: Observable<vscode.SecretStorage> | vscode.SecretStorage
     outputChannel: vscode.OutputChannel
     getAuthInfo?: (secrets: vscode.SecretStorage, providerUri: string) => Promise<AuthInfo | null>
     features: { annotations?: boolean; statusBar?: boolean }
+    providers?: ImportedProviderConfiguration[]
 }): {
     controller: Controller
     apiForTesting: ExtensionApiForTesting
@@ -112,6 +115,7 @@ export function createController({
         makeRange,
         logger: message => outputChannel.appendLine(message),
         importProvider,
+        providers,
     })
 
     const errorTapObserver: Partial<TapObserver<any>> = {

--- a/lib/client/src/configuration.ts
+++ b/lib/client/src/configuration.ts
@@ -1,4 +1,5 @@
 import type { ProviderSettings } from '@openctx/protocol'
+import type { Provider } from '@openctx/provider'
 
 /**
  * Raw configuration set by the user in the client application. Use
@@ -22,14 +23,28 @@ export interface Configuration extends Omit<Required<ConfigurationUserInput>, 'p
     providers: { providerUri: string; settings: ProviderSettings }[]
 }
 
+export interface ImportedProviderConfiguration {
+    providerUri: string
+    settings: boolean | ProviderSettings
+    provider: Provider
+}
 /**
  * Apply defaults to and normalize the raw {@link ConfigurationUserInput}.
  */
-export function configurationFromUserInput(raw: ConfigurationUserInput): Configuration {
+export function configurationFromUserInput(
+    raw: ConfigurationUserInput,
+    providers: ImportedProviderConfiguration[] = []
+): Configuration {
     return {
         enable: raw.enable ?? true,
         debug: raw.debug ?? false,
-        providers: providersFromUserInput(raw.providers),
+        providers: [
+            ...providersFromUserInput(raw.providers),
+            ...providers.map(({ providerUri, settings }) => ({
+                providerUri,
+                settings: typeof settings === 'boolean' ? {} : settings,
+            })),
+        ],
     }
 }
 

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -9,6 +9,7 @@ import type {
     MetaResult,
     ProviderSettings,
 } from '@openctx/protocol'
+import type { Provider } from '@openctx/provider'
 import { scopedLogger } from '../logger.js'
 import { matchSelectors } from './selector.js'
 import { type ProviderTransportOptions, createTransport } from './transport/createTransport.js'
@@ -46,11 +47,12 @@ export interface ProviderClientOptions
  */
 export function createProviderClient(
     providerUri: string,
-    { logger, ...options }: ProviderClientOptions = {}
+    { logger, ...options }: ProviderClientOptions = {},
+    provider?: Provider
 ): ProviderClient {
     logger = scopedLogger(logger, `providerClient(${providerUri})`)
 
-    const transport = createTransport(providerUri, { ...options, cache: true, logger })
+    const transport = provider || createTransport(providerUri, { ...options, cache: true, logger })
 
     return {
         async meta(params: MetaParams, settings: ProviderSettings): Promise<MetaResult> {
@@ -66,7 +68,7 @@ export function createProviderClient(
             settings: ProviderSettings
         ): Promise<MentionsResult | null> {
             try {
-                return await transport.mentions(params, settings)
+                return (await transport.mentions?.(params, settings)) || null
             } catch (error) {
                 logger?.(`failed to get mentions: ${error}`)
                 return Promise.reject(error)
@@ -74,7 +76,7 @@ export function createProviderClient(
         },
         async items(params: ItemsParams, settings: ProviderSettings): Promise<ItemsResult | null> {
             try {
-                return await transport.items(params, settings)
+                return (await transport.items?.(params, settings)) || null
             } catch (error) {
                 logger?.(`failed to get items: ${error}`)
                 return Promise.reject(error)
@@ -105,7 +107,7 @@ export function createProviderClient(
                 return null
             }
             try {
-                return await transport.annotations(params, settings)
+                return (await transport.annotations?.(params, settings)) || null
             } catch (error) {
                 logger?.(`failed to get annotations: ${error}`)
                 return Promise.reject(error)


### PR DESCRIPTION
This PR updated the `createController`, `createClient`, `createProviderClient` to access a list of pre-imported and resolved runtime providers. 

This will allow the consumers of the OpenCtx client to pass in providers as JS objects implementing the Provider interface rather than having to bundle a provider and pass the link to the bundle file.

For now, it will be used by Cody to integrate the remote repositories search provider, which is internal to Cody. 