### PR TITLE
[Docs] Additional note on specifying custom providers in VSCode settings

### DIFF
--- a/web/content/docs/community.mdx
+++ b/web/content/docs/community.mdx
@@ -18,3 +18,4 @@ export const info = {
 ## Mentions from around the web
 
 - [Hack with us on OpenCodeGraph, an experimental OSS project for code context](https://sourcegraph.com/blog/opencodegraph) (announcement post)
+- [OpenCtx update (May 2024)](https://sourcegraph.com/blog/openctx-at-mentions-for-code-ai) (May 2024 update)

--- a/web/content/docs/creating-a-provider.mdx
+++ b/web/content/docs/creating-a-provider.mdx
@@ -57,6 +57,12 @@ You can configure that provider in an OpenCtx client like so:
     "https://openctx.org/npm/@openctx/provider-hello-world": true
 },
 ```
+When developing locally, configure the provider by pointing the bundled `.js` path in the client(eg. VSCode) settings.
+```json
+"openctx.providers": {
+    "file:///<path/to/js/bundle>/index.js": true,
+}
+```
 
 The package's `index.js` file is loaded and expected to have a single default export that satisfies the `Provider` interface.
 


### PR DESCRIPTION
Add an example showing how to specify custom providers locally in VSCode.