### PR TITLE
Provider: remove `@linear/sdk` from the Linear provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,9 +541,6 @@ importers:
 
   provider/linear:
     dependencies:
-      '@linear/sdk':
-        specifier: ^22.0.0
-        version: 22.0.0
       '@openctx/provider':
         specifier: workspace:*
         version: link:../../lib/provider
@@ -3495,14 +3492,6 @@ packages:
       - supports-color
     dev: false
 
-  /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 15.8.0
-    dev: false
-
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -3705,17 +3694,6 @@ packages:
     resolution: {integrity: sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==}
     dependencies:
       '@lezer/common': 1.1.1
-    dev: false
-
-  /@linear/sdk@22.0.0:
-    resolution: {integrity: sha512-sKzTb09w8jfWWuz1TIrVYx4J+9T8AQPxbR6xDlyX19h/bAfwATKf4EHfwJyMoRHDUTW0jhosrzBynpj0DfZuFA==}
-    engines: {node: '>=12.x', yarn: 1.x}
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
-      graphql: 15.8.0
-      isomorphic-unfetch: 3.1.0
-    transitivePeerDependencies:
-      - encoding
     dev: false
 
   /@mapbox/rehype-prism@0.9.0:
@@ -9055,11 +9033,6 @@ packages:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
 
-  /graphql@15.8.0:
-    resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
-    engines: {node: '>= 10.x'}
-    dev: false
-
   /gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
@@ -9784,15 +9757,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /isomorphic-unfetch@3.1.0:
-    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
-    dependencies:
-      node-fetch: 2.7.0
-      unfetch: 4.2.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -13547,10 +13511,6 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     requiresBuild: true
-
-  /unfetch@4.2.0:
-    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
-    dev: false
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}

--- a/provider/linear/README.md
+++ b/provider/linear/README.md
@@ -4,7 +4,12 @@ This is a context provider for [OpenCtx](https://openctx.org) that brings Linear
 
 **Status:** Experimental
 
-## Configuration
+## Configuration for Sourcegraph teammates
+
+1. Find "OpenCtx Linear provider config" in 1Password and add it to your user settings.
+1. Start using the provider!
+
+## Configuration outside of Sourcegraph
 
 To create Linear API credentials:
 

--- a/provider/linear/auth.ts
+++ b/provider/linear/auth.ts
@@ -2,7 +2,6 @@ import { readFileSync, writeFileSync } from 'fs'
 import http from 'http'
 import path from 'path'
 import url, { fileURLToPath } from 'url'
-import { LinearClient } from '@linear/sdk'
 import open from 'open'
 import destroyer from 'server-destroy'
 
@@ -68,7 +67,7 @@ export function createAccessToken(clientConfig?: LinearAuthClientConfig): Promis
                             body: params.toString(),
                         })
 
-                        const tokenData = await tokenResponse.json()
+                        const tokenData = (await tokenResponse.json()) as { access_token?: string }
 
                         if (tokenData.access_token) {
                             resolve(tokenData.access_token)
@@ -97,10 +96,8 @@ export function createAccessToken(clientConfig?: LinearAuthClientConfig): Promis
 
 async function main() {
     const accessToken = await createAccessToken()
-    const client = new LinearClient({ accessToken })
     console.log(`Got access token: ${accessToken}`)
 
-    await client.issueSearch({ query: 'test' })
     const userCredentials = JSON.stringify({ access_token: accessToken } satisfies UserCredentials)
     writeFileSync(userCredentialsPath, userCredentials, {
         encoding: 'utf8',

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -38,7 +38,7 @@ const linearIssues: Provider<Settings> = {
     },
 
     async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {
-        if (!params.query) {
+        if (!params.query || params.query.length < 3) {
             return []
         }
 
@@ -52,7 +52,7 @@ const linearIssues: Provider<Settings> = {
                 }
             }
         `
-        const variables = { query: params.query, first: 25 }
+        const variables = { query: params.query, first: 10 }
         const response = await linearApiRequest(query, variables, settingsInput)
         const issues = response.data.issueSearch.nodes as Issue[]
 

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -44,7 +44,7 @@ const linearIssues: Provider<Settings> = {
 
         const query = `
             query IssueSearch($query: String!, $first: Int!) {
-                issueSearch(query: $query, first: $first) {
+                issueSearch(query: $query, first: $first, orderBy: updatedAt) {
                     nodes {
                         title
                         url

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -91,8 +91,10 @@ const linearIssues: Provider<Settings> = {
         const comments = issue.comments?.nodes as Comment[]
 
         const content = xmlBuilder.build({
-            description: issue.description || '',
-            comments: comments.map(comment => comment.body).join('\n'),
+            linear_issue: {
+                description: issue.description || '',
+                comments: comments.map(comment => comment.body).join('\n'),
+            },
         })
 
         return [

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -7,18 +7,30 @@ import type {
     MetaResult,
     Provider,
 } from '@openctx/provider'
-
-import { LinearClient, type LinearClientOptions } from '@linear/sdk'
 import { XMLBuilder } from 'fast-xml-parser'
+
 import type { UserCredentials } from './auth.js'
 
 /** Settings for the Linear OpenCtx provider. */
 export type Settings = {
     linearUserCredentialsPath?: string
-    linearClientOptions?: LinearClientOptions
+    linearClientCredentials?: { accessToken?: string }
 }
 
 const xmlBuilder = new XMLBuilder({ format: true })
+
+interface Issue {
+    title: string
+    url: string
+    description: string
+    comments?: {
+        nodes: Comment[]
+    }
+}
+
+interface Comment {
+    body: string
+}
 
 const linearIssues: Provider<Settings> = {
     meta(): MetaResult {
@@ -30,10 +42,21 @@ const linearIssues: Provider<Settings> = {
             return []
         }
 
-        const linearClient = getLinearClient(settingsInput)
-        const issues = await linearClient.issueSearch({ query: params.query, first: 25 })
+        const query = `
+            query IssueSearch($query: String!, $first: Int!) {
+                issueSearch(query: $query, first: $first) {
+                    nodes {
+                        title
+                        url
+                    }
+                }
+            }
+        `
+        const variables = { query: params.query, first: 25 }
+        const response = await linearApiRequest(query, variables, settingsInput)
+        const issues = response.data.issueSearch.nodes as Issue[]
 
-        return (issues.nodes ?? []).map(issue => ({
+        return (issues ?? []).map(issue => ({
             title: issue.title,
             uri: issue.url,
         }))
@@ -49,14 +72,27 @@ const linearIssues: Provider<Settings> = {
             return []
         }
 
-        const linearClient = getLinearClient(settingsInput)
-
-        const issue = await linearClient.issue(issueId)
-        const comments = await issue.comments()
+        const query = `
+            query Issue($id: String!) {
+                issue(id: $id) {
+                    title
+                    description
+                    comments {
+                        nodes {
+                            body
+                        }
+                    }
+                }
+            }
+        `
+        const variables = { id: issueId }
+        const data = await linearApiRequest(query, variables, settingsInput)
+        const issue = data.data.issue as Issue
+        const comments = issue.comments?.nodes as Comment[]
 
         const content = xmlBuilder.build({
             description: issue.description || '',
-            comments: comments.nodes.map(comment => comment.body).join('\n'),
+            comments: comments.map(comment => comment.body).join('\n'),
         })
 
         return [
@@ -73,7 +109,11 @@ const linearIssues: Provider<Settings> = {
 
 export default linearIssues
 
-function getLinearClient(settings: Settings): LinearClient {
+function getAccessToken(settings: Settings): string {
+    if (settings.linearClientCredentials?.accessToken) {
+        return settings.linearClientCredentials.accessToken
+    }
+
     if (settings.linearUserCredentialsPath) {
         const userCredentialsString = readFileSync(settings.linearUserCredentialsPath, 'utf-8')
         const userCredentials = JSON.parse(userCredentialsString) as Partial<UserCredentials>
@@ -82,20 +122,40 @@ function getLinearClient(settings: Settings): LinearClient {
             throw new Error(`access_token not found in ${settings.linearUserCredentialsPath}`)
         }
 
-        return new LinearClient({ accessToken: userCredentials.access_token })
-    }
-
-    if (settings.linearClientOptions?.accessToken) {
-        return new LinearClient({ accessToken: settings.linearClientOptions?.accessToken })
-    }
-
-    if (settings.linearClientOptions?.apiKey) {
-        return new LinearClient({ apiKey: settings.linearClientOptions?.apiKey })
+        return userCredentials.access_token
     }
 
     throw new Error(
-        'must provide a Linear user credentials path in the `linearUserCredentialsPath` settings field or a path to a JSON file in the LINEAR_USER_CREDENTIALS_FILE env var'
+        'must provide a Linear user credentials path in the `linearUserCredentialsPath` settings field or an accessToken in the linearClientOptions'
     )
+}
+
+async function linearApiRequest(
+    query: string,
+    variables: object,
+    settings: Settings
+): Promise<{ data: any }> {
+    const accessToken = getAccessToken(settings)
+    const response = await fetch('https://api.linear.app/graphql', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ query, variables }),
+    })
+
+    if (!response.ok) {
+        throw new Error(`Linear API request failed: ${response.statusText}`)
+    }
+
+    const json = (await response.json()) as { data: object }
+
+    if (!json.data) {
+        throw new Error('Linear API request failed: no data')
+    }
+
+    return json
 }
 
 function parseIssueIDFromURL(urlStr: string): string | undefined {

--- a/provider/linear/package.json
+++ b/provider/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-linear",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Linear context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {

--- a/provider/linear/package.json
+++ b/provider/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-linear",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Linear context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {
@@ -14,13 +14,14 @@
   "files": ["dist/bundle.js", "dist/index.d.ts"],
   "sideEffects": false,
   "scripts": {
-    "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
-    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
+    "build": "tsc --build",
+    "bundle:watch": "pnpm run bundle --watch",
+    "bundle": "esbuild --main-fields=module,main --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && pnpm run --silent bundle",
     "test": "vitest",
     "auth": "node --no-warnings=ExperimentalWarning --es-module-specifier-resolution=node --loader ts-node/esm/transpile-only auth.ts"
   },
   "dependencies": {
-    "@linear/sdk": "^22.0.0",
     "@openctx/provider": "workspace:*",
     "fast-xml-parser": "^4.4.0",
     "open": "^10.0.4",


### PR DESCRIPTION
- Removes `@linear/sdk` from the Linear provider to fix bundling issues and reduce the bundle size
- Published a new version with the changes in this PR
- Added the provider config to Linear for dogfooding.

## Test plan

Use creds from 1Password to test it locally.