### PR TITLE
provider: initial DevDocs provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,21 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
 
+  provider/devdocs:
+    dependencies:
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+      fuse.js:
+        specifier: ^7.0.0
+        version: 7.0.0
+      lru-cache:
+        specifier: ^10.1.0
+        version: 10.1.0
+      node-html-parser:
+        specifier: ^6.1.13
+        version: 6.1.13
+
   provider/github:
     dependencies:
       '@octokit/core':
@@ -7060,7 +7075,6 @@ packages:
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-    dev: true
 
   /bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
@@ -7679,7 +7693,6 @@ packages:
       domhandler: 5.0.3
       domutils: 3.1.0
       nth-check: 2.1.1
-    dev: true
 
   /css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
@@ -7692,7 +7705,6 @@ packages:
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -8795,6 +8807,11 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
+  /fuse.js@7.0.0:
+    resolution: {integrity: sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==}
+    engines: {node: '>=10'}
+    dev: false
+
   /gaxios@6.5.0:
     resolution: {integrity: sha512-R9QGdv8j4/dlNoQbX3hSaK/S0rkMijqjVvW3YM06CoBdbU/VdKd159j4hePpng0KuE6Lh6JJ7UdmVGJZFcAG1w==}
     engines: {node: '>=14'}
@@ -9232,7 +9249,6 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
-    dev: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -11173,6 +11189,13 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
 
+  /node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+    dependencies:
+      css-select: 5.1.0
+      he: 1.2.0
+    dev: false
+
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
@@ -11226,7 +11249,6 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
     dependencies:
       boolbase: 1.0.0
-    dev: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}

--- a/provider/devdocs/.gitattributes
+++ b/provider/devdocs/.gitattributes
@@ -1,0 +1,1 @@
+**/__fixtures__/** linguist-generated=true

--- a/provider/devdocs/README.md
+++ b/provider/devdocs/README.md
@@ -1,0 +1,24 @@
+# DevDocs page context provider for OpenCtx
+
+This is a context provider for [OpenCtx](https://openctx.org) that fetches contents from https://devdocs.io/ pages by name for use as context.
+
+## Usage
+
+Add the following to your settings in any OpenCtx client:
+
+```json
+"openctx.providers": {
+    // ...other providers...
+    "https://openctx.org/npm/@openctx/provider-devdocs": {
+        "urls": ["https://devdocs.io/go/", "https://devdocs.io/angular~16/"]
+    }
+},
+```
+
+A URL is any top-level documentation URL on https://devdocs.io/. 
+
+## Development
+
+- [Source code](https://sourcegraph.com/github.com/sourcegraph/openctx/-/tree/provider/devdocs)
+- [Docs](https://openctx.org/docs/providers/devdocs)
+- License: Apache 2.0

--- a/provider/devdocs/__fixtures__/index.json
+++ b/provider/devdocs/__fixtures__/index.json
@@ -1,0 +1,70 @@
+{
+  "entries": [
+    { "name": "io.TeeReader()", "path": "io/index#TeeReader", "type": "io" },
+    { "name": "strconv", "path": "strconv/index", "type": "strconv" },
+    { "name": "strconv constants", "path": "strconv/index#pkg-constants", "type": "strconv" },
+    { "name": "strconv variables", "path": "strconv/index#pkg-variables", "type": "strconv" },
+    { "name": "strconv.AppendBool()", "path": "strconv/index#AppendBool", "type": "strconv" },
+    { "name": "strconv.AppendFloat()", "path": "strconv/index#AppendFloat", "type": "strconv" },
+    { "name": "strconv.AppendInt()", "path": "strconv/index#AppendInt", "type": "strconv" },
+    { "name": "strconv.AppendQuote()", "path": "strconv/index#AppendQuote", "type": "strconv" },
+    { "name": "strconv.AppendQuoteRune()", "path": "strconv/index#AppendQuoteRune", "type": "strconv" },
+    {
+      "name": "strconv.AppendQuoteRuneToASCII()",
+      "path": "strconv/index#AppendQuoteRuneToASCII",
+      "type": "strconv"
+    },
+    {
+      "name": "strconv.AppendQuoteRuneToGraphic()",
+      "path": "strconv/index#AppendQuoteRuneToGraphic",
+      "type": "strconv"
+    },
+    {
+      "name": "strconv.AppendQuoteToASCII()",
+      "path": "strconv/index#AppendQuoteToASCII",
+      "type": "strconv"
+    },
+    {
+      "name": "strconv.AppendQuoteToGraphic()",
+      "path": "strconv/index#AppendQuoteToGraphic",
+      "type": "strconv"
+    },
+    { "name": "strconv.AppendUint()", "path": "strconv/index#AppendUint", "type": "strconv" },
+    { "name": "strconv.Atoi()", "path": "strconv/index#Atoi", "type": "strconv" },
+    { "name": "strconv.CanBackquote()", "path": "strconv/index#CanBackquote", "type": "strconv" },
+    { "name": "strconv.FormatBool()", "path": "strconv/index#FormatBool", "type": "strconv" },
+    { "name": "strconv.FormatComplex()", "path": "strconv/index#FormatComplex", "type": "strconv" },
+    { "name": "strconv.FormatFloat()", "path": "strconv/index#FormatFloat", "type": "strconv" },
+    { "name": "strconv.FormatInt()", "path": "strconv/index#FormatInt", "type": "strconv" },
+    { "name": "strconv.FormatUint()", "path": "strconv/index#FormatUint", "type": "strconv" },
+    { "name": "strconv.IsGraphic()", "path": "strconv/index#IsGraphic", "type": "strconv" },
+    { "name": "strconv.IsPrint()", "path": "strconv/index#IsPrint", "type": "strconv" },
+    { "name": "strconv.Itoa()", "path": "strconv/index#Itoa", "type": "strconv" },
+    { "name": "strconv.NumError", "path": "strconv/index#NumError", "type": "strconv" },
+    { "name": "strconv.NumError.Error()", "path": "strconv/index#NumError.Error", "type": "strconv" },
+    { "name": "strconv.NumError.Unwrap()", "path": "strconv/index#NumError.Unwrap", "type": "strconv" },
+    { "name": "strconv.ParseBool()", "path": "strconv/index#ParseBool", "type": "strconv" },
+    { "name": "strconv.ParseComplex()", "path": "strconv/index#ParseComplex", "type": "strconv" },
+    { "name": "strconv.ParseFloat()", "path": "strconv/index#ParseFloat", "type": "strconv" },
+    { "name": "strconv.ParseInt()", "path": "strconv/index#ParseInt", "type": "strconv" },
+    { "name": "strconv.ParseUint()", "path": "strconv/index#ParseUint", "type": "strconv" },
+    { "name": "strconv.Quote()", "path": "strconv/index#Quote", "type": "strconv" },
+    { "name": "strconv.QuotedPrefix()", "path": "strconv/index#QuotedPrefix", "type": "strconv" },
+    { "name": "strconv.QuoteRune()", "path": "strconv/index#QuoteRune", "type": "strconv" },
+    {
+      "name": "strconv.QuoteRuneToASCII()",
+      "path": "strconv/index#QuoteRuneToASCII",
+      "type": "strconv"
+    },
+    {
+      "name": "strconv.QuoteRuneToGraphic()",
+      "path": "strconv/index#QuoteRuneToGraphic",
+      "type": "strconv"
+    },
+    { "name": "strconv.QuoteToASCII()", "path": "strconv/index#QuoteToASCII", "type": "strconv" },
+    { "name": "strconv.QuoteToGraphic()", "path": "strconv/index#QuoteToGraphic", "type": "strconv" },
+    { "name": "strconv.Unquote()", "path": "strconv/index#Unquote", "type": "strconv" },
+    { "name": "strconv.UnquoteChar()", "path": "strconv/index#UnquoteChar", "type": "strconv" }
+  ],
+  "types": []
+}

--- a/provider/devdocs/__fixtures__/io/index.html
+++ b/provider/devdocs/__fixtures__/io/index.html
@@ -1,0 +1,461 @@
+<h1> Package io  </h1>     <ul id="short-nav">
+<li><code>import "io"</code></li>
+<li><a href="#pkg-overview" class="overviewLink">Overview</a></li>
+<li><a href="#pkg-index" class="indexLink">Index</a></li>
+<li><a href="#pkg-examples" class="examplesLink">Examples</a></li>
+<li><a href="#pkg-subdirectories">Subdirectories</a></li>
+</ul>     <h2 id="pkg-overview">Overview </h2> <p>Package io provides basic interfaces to I/O primitives. Its primary job is to wrap existing implementations of such primitives, such as those in package os, into shared public interfaces that abstract the functionality, plus some other related primitives. </p>
+<p>Because these interfaces and primitives wrap lower-level operations with various implementations, unless otherwise informed clients should not assume they are safe for parallel execution. </p>     <h2 id="pkg-index">Index </h2>  <ul id="manual-nav">
+<li><a href="#pkg-constants">Constants</a></li>
+<li><a href="#pkg-variables">Variables</a></li>
+<li><a href="#Copy">func Copy(dst Writer, src Reader) (written int64, err error)</a></li>
+<li><a href="#CopyBuffer">func CopyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error)</a></li>
+<li><a href="#CopyN">func CopyN(dst Writer, src Reader, n int64) (written int64, err error)</a></li>
+<li><a href="#Pipe">func Pipe() (*PipeReader, *PipeWriter)</a></li>
+<li><a href="#ReadAll">func ReadAll(r Reader) ([]byte, error)</a></li>
+<li><a href="#ReadAtLeast">func ReadAtLeast(r Reader, buf []byte, min int) (n int, err error)</a></li>
+<li><a href="#ReadFull">func ReadFull(r Reader, buf []byte) (n int, err error)</a></li>
+<li><a href="#WriteString">func WriteString(w Writer, s string) (n int, err error)</a></li>
+<li><a href="#ByteReader">type ByteReader</a></li>
+<li><a href="#ByteScanner">type ByteScanner</a></li>
+<li><a href="#ByteWriter">type ByteWriter</a></li>
+<li><a href="#Closer">type Closer</a></li>
+<li><a href="#LimitedReader">type LimitedReader</a></li>
+<li> <a href="#LimitedReader.Read">func (l *LimitedReader) Read(p []byte) (n int, err error)</a>
+</li>
+<li><a href="#OffsetWriter">type OffsetWriter</a></li>
+<li> <a href="#NewOffsetWriter">func NewOffsetWriter(w WriterAt, off int64) *OffsetWriter</a>
+</li>
+<li> <a href="#OffsetWriter.Seek">func (o *OffsetWriter) Seek(offset int64, whence int) (int64, error)</a>
+</li>
+<li> <a href="#OffsetWriter.Write">func (o *OffsetWriter) Write(p []byte) (n int, err error)</a>
+</li>
+<li> <a href="#OffsetWriter.WriteAt">func (o *OffsetWriter) WriteAt(p []byte, off int64) (n int, err error)</a>
+</li>
+<li><a href="#PipeReader">type PipeReader</a></li>
+<li> <a href="#PipeReader.Close">func (r *PipeReader) Close() error</a>
+</li>
+<li> <a href="#PipeReader.CloseWithError">func (r *PipeReader) CloseWithError(err error) error</a>
+</li>
+<li> <a href="#PipeReader.Read">func (r *PipeReader) Read(data []byte) (n int, err error)</a>
+</li>
+<li><a href="#PipeWriter">type PipeWriter</a></li>
+<li> <a href="#PipeWriter.Close">func (w *PipeWriter) Close() error</a>
+</li>
+<li> <a href="#PipeWriter.CloseWithError">func (w *PipeWriter) CloseWithError(err error) error</a>
+</li>
+<li> <a href="#PipeWriter.Write">func (w *PipeWriter) Write(data []byte) (n int, err error)</a>
+</li>
+<li><a href="#ReadCloser">type ReadCloser</a></li>
+<li> <a href="#NopCloser">func NopCloser(r Reader) ReadCloser</a>
+</li>
+<li><a href="#ReadSeekCloser">type ReadSeekCloser</a></li>
+<li><a href="#ReadSeeker">type ReadSeeker</a></li>
+<li><a href="#ReadWriteCloser">type ReadWriteCloser</a></li>
+<li><a href="#ReadWriteSeeker">type ReadWriteSeeker</a></li>
+<li><a href="#ReadWriter">type ReadWriter</a></li>
+<li><a href="#Reader">type Reader</a></li>
+<li> <a href="#LimitReader">func LimitReader(r Reader, n int64) Reader</a>
+</li>
+<li> <a href="#MultiReader">func MultiReader(readers ...Reader) Reader</a>
+</li>
+<li> <a href="#TeeReader">func TeeReader(r Reader, w Writer) Reader</a>
+</li>
+<li><a href="#ReaderAt">type ReaderAt</a></li>
+<li><a href="#ReaderFrom">type ReaderFrom</a></li>
+<li><a href="#RuneReader">type RuneReader</a></li>
+<li><a href="#RuneScanner">type RuneScanner</a></li>
+<li><a href="#SectionReader">type SectionReader</a></li>
+<li> <a href="#NewSectionReader">func NewSectionReader(r ReaderAt, off int64, n int64) *SectionReader</a>
+</li>
+<li> <a href="#SectionReader.Outer">func (s *SectionReader) Outer() (r ReaderAt, off int64, n int64)</a>
+</li>
+<li> <a href="#SectionReader.Read">func (s *SectionReader) Read(p []byte) (n int, err error)</a>
+</li>
+<li> <a href="#SectionReader.ReadAt">func (s *SectionReader) ReadAt(p []byte, off int64) (n int, err error)</a>
+</li>
+<li> <a href="#SectionReader.Seek">func (s *SectionReader) Seek(offset int64, whence int) (int64, error)</a>
+</li>
+<li> <a href="#SectionReader.Size">func (s *SectionReader) Size() int64</a>
+</li>
+<li><a href="#Seeker">type Seeker</a></li>
+<li><a href="#StringWriter">type StringWriter</a></li>
+<li><a href="#WriteCloser">type WriteCloser</a></li>
+<li><a href="#WriteSeeker">type WriteSeeker</a></li>
+<li><a href="#Writer">type Writer</a></li>
+<li> <a href="#MultiWriter">func MultiWriter(writers ...Writer) Writer</a>
+</li>
+<li><a href="#WriterAt">type WriterAt</a></li>
+<li><a href="#WriterTo">type WriterTo</a></li>
+</ul> <div id="pkg-examples"> <h3>Examples</h3>  <dl> <dd><a class="exampleLink" href="#example_Copy">Copy</a></dd> <dd><a class="exampleLink" href="#example_CopyBuffer">CopyBuffer</a></dd> <dd><a class="exampleLink" href="#example_CopyN">CopyN</a></dd> <dd><a class="exampleLink" href="#example_LimitReader">LimitReader</a></dd> <dd><a class="exampleLink" href="#example_MultiReader">MultiReader</a></dd> <dd><a class="exampleLink" href="#example_MultiWriter">MultiWriter</a></dd> <dd><a class="exampleLink" href="#example_Pipe">Pipe</a></dd> <dd><a class="exampleLink" href="#example_ReadAll">ReadAll</a></dd> <dd><a class="exampleLink" href="#example_ReadAtLeast">ReadAtLeast</a></dd> <dd><a class="exampleLink" href="#example_ReadFull">ReadFull</a></dd> <dd><a class="exampleLink" href="#example_SectionReader">SectionReader</a></dd> <dd><a class="exampleLink" href="#example_SectionReader_Read">SectionReader.Read</a></dd> <dd><a class="exampleLink" href="#example_SectionReader_ReadAt">SectionReader.ReadAt</a></dd> <dd><a class="exampleLink" href="#example_SectionReader_Seek">SectionReader.Seek</a></dd> <dd><a class="exampleLink" href="#example_SectionReader_Size">SectionReader.Size</a></dd> <dd><a class="exampleLink" href="#example_TeeReader">TeeReader</a></dd> <dd><a class="exampleLink" href="#example_WriteString">WriteString</a></dd> </dl> </div> <h3>Package files</h3> <p>  <span>io.go</span> <span>multi.go</span> <span>pipe.go</span>  </p>   <h2 id="pkg-constants">Constants</h2> <p>Seek whence values. </p>
+<pre data-language="go">const (
+    SeekStart   = 0 // seek relative to the origin of the file
+    SeekCurrent = 1 // seek relative to the current offset
+    SeekEnd     = 2 // seek relative to the end
+)</pre> <h2 id="pkg-variables">Variables</h2> <p>EOF is the error returned by Read when no more input is available. (Read must return EOF itself, not an error wrapping EOF, because callers will test for EOF using ==.) Functions should return EOF only to signal a graceful end of input. If the EOF occurs unexpectedly in a structured data stream, the appropriate error is either <a href="#ErrUnexpectedEOF">ErrUnexpectedEOF</a> or some other error giving more detail. </p>
+<pre data-language="go">var EOF = errors.New("EOF")</pre> <p>ErrClosedPipe is the error used for read or write operations on a closed pipe. </p>
+<pre data-language="go">var ErrClosedPipe = errors.New("io: read/write on closed pipe")</pre> <p>ErrNoProgress is returned by some clients of a <a href="#Reader">Reader</a> when many calls to Read have failed to return any data or error, usually the sign of a broken <a href="#Reader">Reader</a> implementation. </p>
+<pre data-language="go">var ErrNoProgress = errors.New("multiple Read calls return no data or error")</pre> <p>ErrShortBuffer means that a read required a longer buffer than was provided. </p>
+<pre data-language="go">var ErrShortBuffer = errors.New("short buffer")</pre> <p>ErrShortWrite means that a write accepted fewer bytes than requested but failed to return an explicit error. </p>
+<pre data-language="go">var ErrShortWrite = errors.New("short write")</pre> <p>ErrUnexpectedEOF means that EOF was encountered in the middle of reading a fixed-size block or data structure. </p>
+<pre data-language="go">var ErrUnexpectedEOF = errors.New("unexpected EOF")</pre> <h2 id="Copy">func <span>Copy</span>  </h2> <pre data-language="go">func Copy(dst Writer, src Reader) (written int64, err error)</pre> <p>Copy copies from src to dst until either EOF is reached on src or an error occurs. It returns the number of bytes copied and the first error encountered while copying, if any. </p>
+<p>A successful Copy returns err == nil, not err == EOF. Because Copy is defined to read from src until EOF, it does not treat an EOF from Read as an error to be reported. </p>
+<p>If src implements <a href="#WriterTo">WriterTo</a>, the copy is implemented by calling src.WriteTo(dst). Otherwise, if dst implements <a href="#ReaderFrom">ReaderFrom</a>, the copy is implemented by calling dst.ReadFrom(src). </p>   <h4 id="example_Copy"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+
+if _, err := io.Copy(os.Stdout, r); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some io.Reader stream to be read
+</pre>   <h2 id="CopyBuffer">func <span>CopyBuffer</span>  <span title="Added in Go 1.5">1.5</span> </h2> <pre data-language="go">func CopyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error)</pre> <p>CopyBuffer is identical to Copy except that it stages through the provided buffer (if one is required) rather than allocating a temporary one. If buf is nil, one is allocated; otherwise if it has zero length, CopyBuffer panics. </p>
+<p>If either src implements <a href="#WriterTo">WriterTo</a> or dst implements <a href="#ReaderFrom">ReaderFrom</a>, buf will not be used to perform the copy. </p>   <h4 id="example_CopyBuffer"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r1 := strings.NewReader("first reader\n")
+r2 := strings.NewReader("second reader\n")
+buf := make([]byte, 8)
+
+// buf is used here...
+if _, err := io.CopyBuffer(os.Stdout, r1, buf); err != nil {
+    log.Fatal(err)
+}
+
+// ... reused here also. No need to allocate an extra buffer.
+if _, err := io.CopyBuffer(os.Stdout, r2, buf); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">first reader
+second reader
+</pre>   <h2 id="CopyN">func <span>CopyN</span>  </h2> <pre data-language="go">func CopyN(dst Writer, src Reader, n int64) (written int64, err error)</pre> <p>CopyN copies n bytes (or until an error) from src to dst. It returns the number of bytes copied and the earliest error encountered while copying. On return, written == n if and only if err == nil. </p>
+<p>If dst implements <a href="#ReaderFrom">ReaderFrom</a>, the copy is implemented using it. </p>   <h4 id="example_CopyN"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read")
+
+if _, err := io.CopyN(os.Stdout, r, 4); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some
+</pre>   <h2 id="Pipe">func <span>Pipe</span>  </h2> <pre data-language="go">func Pipe() (*PipeReader, *PipeWriter)</pre> <p>Pipe creates a synchronous in-memory pipe. It can be used to connect code expecting an <a href="#Reader">io.Reader</a> with code expecting an <a href="#Writer">io.Writer</a>. </p>
+<p>Reads and Writes on the pipe are matched one to one except when multiple Reads are needed to consume a single Write. That is, each Write to the <a href="#PipeWriter">PipeWriter</a> blocks until it has satisfied one or more Reads from the <a href="#PipeReader">PipeReader</a> that fully consume the written data. The data is copied directly from the Write to the corresponding Read (or Reads); there is no internal buffering. </p>
+<p>It is safe to call Read and Write in parallel with each other or with Close. Parallel calls to Read and parallel calls to Write are also safe: the individual calls will be gated sequentially. </p>   <h4 id="example_Pipe"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r, w := io.Pipe()
+
+go func() {
+    fmt.Fprint(w, "some io.Reader stream to be read\n")
+    w.Close()
+}()
+
+if _, err := io.Copy(os.Stdout, r); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some io.Reader stream to be read
+</pre>   <h2 id="ReadAll">func <span>ReadAll</span>  <span title="Added in Go 1.16">1.16</span> </h2> <pre data-language="go">func ReadAll(r Reader) ([]byte, error)</pre> <p>ReadAll reads from r until an error or EOF and returns the data it read. A successful call returns err == nil, not err == EOF. Because ReadAll is defined to read from src until EOF, it does not treat an EOF from Read as an error to be reported. </p>   <h4 id="example_ReadAll"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("Go is a general-purpose language designed with systems programming in mind.")
+
+b, err := io.ReadAll(r)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("%s", b)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">Go is a general-purpose language designed with systems programming in mind.
+</pre>   <h2 id="ReadAtLeast">func <span>ReadAtLeast</span>  </h2> <pre data-language="go">func ReadAtLeast(r Reader, buf []byte, min int) (n int, err error)</pre> <p>ReadAtLeast reads from r into buf until it has read at least min bytes. It returns the number of bytes copied and an error if fewer bytes were read. The error is EOF only if no bytes were read. If an EOF happens after reading fewer than min bytes, ReadAtLeast returns <a href="#ErrUnexpectedEOF">ErrUnexpectedEOF</a>. If min is greater than the length of buf, ReadAtLeast returns <a href="#ErrShortBuffer">ErrShortBuffer</a>. On return, n &gt;= min if and only if err == nil. If r returns an error having read at least min bytes, the error is dropped. </p>   <h4 id="example_ReadAtLeast"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+
+buf := make([]byte, 14)
+if _, err := io.ReadAtLeast(r, buf, 4); err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("%s\n", buf)
+
+// buffer smaller than minimal read size.
+shortBuf := make([]byte, 3)
+if _, err := io.ReadAtLeast(r, shortBuf, 4); err != nil {
+    fmt.Println("error:", err)
+}
+
+// minimal read size bigger than io.Reader stream
+longBuf := make([]byte, 64)
+if _, err := io.ReadAtLeast(r, longBuf, 64); err != nil {
+    fmt.Println("error:", err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some io.Reader
+error: short buffer
+error: unexpected EOF
+</pre>   <h2 id="ReadFull">func <span>ReadFull</span>  </h2> <pre data-language="go">func ReadFull(r Reader, buf []byte) (n int, err error)</pre> <p>ReadFull reads exactly len(buf) bytes from r into buf. It returns the number of bytes copied and an error if fewer bytes were read. The error is EOF only if no bytes were read. If an EOF happens after reading some but not all the bytes, ReadFull returns <a href="#ErrUnexpectedEOF">ErrUnexpectedEOF</a>. On return, n == len(buf) if and only if err == nil. If r returns an error having read at least len(buf) bytes, the error is dropped. </p>   <h4 id="example_ReadFull"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+
+buf := make([]byte, 4)
+if _, err := io.ReadFull(r, buf); err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("%s\n", buf)
+
+// minimal read size bigger than io.Reader stream
+longBuf := make([]byte, 64)
+if _, err := io.ReadFull(r, longBuf); err != nil {
+    fmt.Println("error:", err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some
+error: unexpected EOF
+</pre>   <h2 id="WriteString">func <span>WriteString</span>  </h2> <pre data-language="go">func WriteString(w Writer, s string) (n int, err error)</pre> <p>WriteString writes the contents of the string s to w, which accepts a slice of bytes. If w implements <a href="#StringWriter">StringWriter</a>, [StringWriter.WriteString] is invoked directly. Otherwise, [Writer.Write] is called exactly once. </p>   <h4 id="example_WriteString"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">if _, err := io.WriteString(os.Stdout, "Hello World"); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">Hello World
+</pre>   <h2 id="ByteReader">type <span>ByteReader</span>  </h2> <p>ByteReader is the interface that wraps the ReadByte method. </p>
+<p>ReadByte reads and returns the next byte from the input or any error encountered. If ReadByte returns an error, no input byte was consumed, and the returned byte value is undefined. </p>
+<p>ReadByte provides an efficient interface for byte-at-time processing. A <a href="#Reader">Reader</a> that does not implement ByteReader can be wrapped using bufio.NewReader to add this method. </p>
+<pre data-language="go">type ByteReader interface {
+    ReadByte() (byte, error)
+}</pre> <h2 id="ByteScanner">type <span>ByteScanner</span>  </h2> <p>ByteScanner is the interface that adds the UnreadByte method to the basic ReadByte method. </p>
+<p>UnreadByte causes the next call to ReadByte to return the last byte read. If the last operation was not a successful call to ReadByte, UnreadByte may return an error, unread the last byte read (or the byte prior to the last-unread byte), or (in implementations that support the <a href="#Seeker">Seeker</a> interface) seek to one byte before the current offset. </p>
+<pre data-language="go">type ByteScanner interface {
+    ByteReader
+    UnreadByte() error
+}</pre> <h2 id="ByteWriter">type <span>ByteWriter</span>  <span title="Added in Go 1.1">1.1</span> </h2> <p>ByteWriter is the interface that wraps the WriteByte method. </p>
+<pre data-language="go">type ByteWriter interface {
+    WriteByte(c byte) error
+}</pre> <h2 id="Closer">type <span>Closer</span>  </h2> <p>Closer is the interface that wraps the basic Close method. </p>
+<p>The behavior of Close after the first call is undefined. Specific implementations may document their own behavior. </p>
+<pre data-language="go">type Closer interface {
+    Close() error
+}</pre> <h2 id="LimitedReader">type <span>LimitedReader</span>  </h2> <p>A LimitedReader reads from R but limits the amount of data returned to just N bytes. Each call to Read updates N to reflect the new amount remaining. Read returns EOF when N &lt;= 0 or when the underlying R returns EOF. </p>
+<pre data-language="go">type LimitedReader struct {
+    R Reader // underlying reader
+    N int64  // max bytes remaining
+}
+</pre> <h3 id="LimitedReader.Read">func (*LimitedReader) <span>Read</span>  </h3> <pre data-language="go">func (l *LimitedReader) Read(p []byte) (n int, err error)</pre> <h2 id="OffsetWriter">type <span>OffsetWriter</span>  <span title="Added in Go 1.20">1.20</span> </h2> <p>An OffsetWriter maps writes at offset base to offset base+off in the underlying writer. </p>
+<pre data-language="go">type OffsetWriter struct {
+    // contains filtered or unexported fields
+}
+</pre> <h3 id="NewOffsetWriter">func <span>NewOffsetWriter</span>  <span title="Added in Go 1.20">1.20</span> </h3> <pre data-language="go">func NewOffsetWriter(w WriterAt, off int64) *OffsetWriter</pre> <p>NewOffsetWriter returns an <a href="#OffsetWriter">OffsetWriter</a> that writes to w starting at offset off. </p>
+<h3 id="OffsetWriter.Seek">func (*OffsetWriter) <span>Seek</span>  <span title="Added in Go 1.20">1.20</span> </h3> <pre data-language="go">func (o *OffsetWriter) Seek(offset int64, whence int) (int64, error)</pre> <h3 id="OffsetWriter.Write">func (*OffsetWriter) <span>Write</span>  <span title="Added in Go 1.20">1.20</span> </h3> <pre data-language="go">func (o *OffsetWriter) Write(p []byte) (n int, err error)</pre> <h3 id="OffsetWriter.WriteAt">func (*OffsetWriter) <span>WriteAt</span>  <span title="Added in Go 1.20">1.20</span> </h3> <pre data-language="go">func (o *OffsetWriter) WriteAt(p []byte, off int64) (n int, err error)</pre> <h2 id="PipeReader">type <span>PipeReader</span>  </h2> <p>A PipeReader is the read half of a pipe. </p>
+<pre data-language="go">type PipeReader struct {
+    // contains filtered or unexported fields
+}
+</pre> <h3 id="PipeReader.Close">func (*PipeReader) <span>Close</span>  </h3> <pre data-language="go">func (r *PipeReader) Close() error</pre> <p>Close closes the reader; subsequent writes to the write half of the pipe will return the error <a href="#ErrClosedPipe">ErrClosedPipe</a>. </p>
+<h3 id="PipeReader.CloseWithError">func (*PipeReader) <span>CloseWithError</span>  </h3> <pre data-language="go">func (r *PipeReader) CloseWithError(err error) error</pre> <p>CloseWithError closes the reader; subsequent writes to the write half of the pipe will return the error err. </p>
+<p>CloseWithError never overwrites the previous error if it exists and always returns nil. </p>
+<h3 id="PipeReader.Read">func (*PipeReader) <span>Read</span>  </h3> <pre data-language="go">func (r *PipeReader) Read(data []byte) (n int, err error)</pre> <p>Read implements the standard Read interface: it reads data from the pipe, blocking until a writer arrives or the write end is closed. If the write end is closed with an error, that error is returned as err; otherwise err is EOF. </p>
+<h2 id="PipeWriter">type <span>PipeWriter</span>  </h2> <p>A PipeWriter is the write half of a pipe. </p>
+<pre data-language="go">type PipeWriter struct {
+    // contains filtered or unexported fields
+}
+</pre> <h3 id="PipeWriter.Close">func (*PipeWriter) <span>Close</span>  </h3> <pre data-language="go">func (w *PipeWriter) Close() error</pre> <p>Close closes the writer; subsequent reads from the read half of the pipe will return no bytes and EOF. </p>
+<h3 id="PipeWriter.CloseWithError">func (*PipeWriter) <span>CloseWithError</span>  </h3> <pre data-language="go">func (w *PipeWriter) CloseWithError(err error) error</pre> <p>CloseWithError closes the writer; subsequent reads from the read half of the pipe will return no bytes and the error err, or EOF if err is nil. </p>
+<p>CloseWithError never overwrites the previous error if it exists and always returns nil. </p>
+<h3 id="PipeWriter.Write">func (*PipeWriter) <span>Write</span>  </h3> <pre data-language="go">func (w *PipeWriter) Write(data []byte) (n int, err error)</pre> <p>Write implements the standard Write interface: it writes data to the pipe, blocking until one or more readers have consumed all the data or the read end is closed. If the read end is closed with an error, that err is returned as err; otherwise err is <a href="#ErrClosedPipe">ErrClosedPipe</a>. </p>
+<h2 id="ReadCloser">type <span>ReadCloser</span>  </h2> <p>ReadCloser is the interface that groups the basic Read and Close methods. </p>
+<pre data-language="go">type ReadCloser interface {
+    Reader
+    Closer
+}</pre> <h3 id="NopCloser">func <span>NopCloser</span>  <span title="Added in Go 1.16">1.16</span> </h3> <pre data-language="go">func NopCloser(r Reader) ReadCloser</pre> <p>NopCloser returns a <a href="#ReadCloser">ReadCloser</a> with a no-op Close method wrapping the provided <a href="#Reader">Reader</a> r. If r implements <a href="#WriterTo">WriterTo</a>, the returned <a href="#ReadCloser">ReadCloser</a> will implement <a href="#WriterTo">WriterTo</a> by forwarding calls to r. </p>
+<h2 id="ReadSeekCloser">type <span>ReadSeekCloser</span>  <span title="Added in Go 1.16">1.16</span> </h2> <p>ReadSeekCloser is the interface that groups the basic Read, Seek and Close methods. </p>
+<pre data-language="go">type ReadSeekCloser interface {
+    Reader
+    Seeker
+    Closer
+}</pre> <h2 id="ReadSeeker">type <span>ReadSeeker</span>  </h2> <p>ReadSeeker is the interface that groups the basic Read and Seek methods. </p>
+<pre data-language="go">type ReadSeeker interface {
+    Reader
+    Seeker
+}</pre> <h2 id="ReadWriteCloser">type <span>ReadWriteCloser</span>  </h2> <p>ReadWriteCloser is the interface that groups the basic Read, Write and Close methods. </p>
+<pre data-language="go">type ReadWriteCloser interface {
+    Reader
+    Writer
+    Closer
+}</pre> <h2 id="ReadWriteSeeker">type <span>ReadWriteSeeker</span>  </h2> <p>ReadWriteSeeker is the interface that groups the basic Read, Write and Seek methods. </p>
+<pre data-language="go">type ReadWriteSeeker interface {
+    Reader
+    Writer
+    Seeker
+}</pre> <h2 id="ReadWriter">type <span>ReadWriter</span>  </h2> <p>ReadWriter is the interface that groups the basic Read and Write methods. </p>
+<pre data-language="go">type ReadWriter interface {
+    Reader
+    Writer
+}</pre> <h2 id="Reader">type <span>Reader</span>  </h2> <p>Reader is the interface that wraps the basic Read method. </p>
+<p>Read reads up to len(p) bytes into p. It returns the number of bytes read (0 &lt;= n &lt;= len(p)) and any error encountered. Even if Read returns n &lt; len(p), it may use all of p as scratch space during the call. If some data is available but not len(p) bytes, Read conventionally returns what is available instead of waiting for more. </p>
+<p>When Read encounters an error or end-of-file condition after successfully reading n &gt; 0 bytes, it returns the number of bytes read. It may return the (non-nil) error from the same call or return the error (and n == 0) from a subsequent call. An instance of this general case is that a Reader returning a non-zero number of bytes at the end of the input stream may return either err == EOF or err == nil. The next Read should return 0, EOF. </p>
+<p>Callers should always process the n &gt; 0 bytes returned before considering the error err. Doing so correctly handles I/O errors that happen after reading some bytes and also both of the allowed EOF behaviors. </p>
+<p>If len(p) == 0, Read should always return n == 0. It may return a non-nil error if some error condition is known, such as EOF. </p>
+<p>Implementations of Read are discouraged from returning a zero byte count with a nil error, except when len(p) == 0. Callers should treat a return of 0 and nil as indicating that nothing happened; in particular it does not indicate EOF. </p>
+<p>Implementations must not retain p. </p>
+<pre data-language="go">type Reader interface {
+    Read(p []byte) (n int, err error)
+}</pre> <h3 id="LimitReader">func <span>LimitReader</span>  </h3> <pre data-language="go">func LimitReader(r Reader, n int64) Reader</pre> <p>LimitReader returns a Reader that reads from r but stops with EOF after n bytes. The underlying implementation is a *LimitedReader. </p>   <h4 id="example_LimitReader"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+lr := io.LimitReader(r, 4)
+
+if _, err := io.Copy(os.Stdout, lr); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some
+</pre>   <h3 id="MultiReader">func <span>MultiReader</span>  </h3> <pre data-language="go">func MultiReader(readers ...Reader) Reader</pre> <p>MultiReader returns a Reader that's the logical concatenation of the provided input readers. They're read sequentially. Once all inputs have returned EOF, Read will return EOF. If any of the readers return a non-nil, non-EOF error, Read will return that error. </p>   <h4 id="example_MultiReader"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r1 := strings.NewReader("first reader ")
+r2 := strings.NewReader("second reader ")
+r3 := strings.NewReader("third reader\n")
+r := io.MultiReader(r1, r2, r3)
+
+if _, err := io.Copy(os.Stdout, r); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">first reader second reader third reader
+</pre>   <h3 id="TeeReader">func <span>TeeReader</span>  </h3> <pre data-language="go">func TeeReader(r Reader, w Writer) Reader</pre> <p>TeeReader returns a <a href="#Reader">Reader</a> that writes to w what it reads from r. All reads from r performed through it are matched with corresponding writes to w. There is no internal buffering - the write must complete before the read completes. Any error encountered while writing is reported as a read error. </p>   <h4 id="example_TeeReader"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">var r io.Reader = strings.NewReader("some io.Reader stream to be read\n")
+
+r = io.TeeReader(r, os.Stdout)
+
+// Everything read from r will be copied to stdout.
+if _, err := io.ReadAll(r); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some io.Reader stream to be read
+</pre>   <h2 id="ReaderAt">type <span>ReaderAt</span>  </h2> <p>ReaderAt is the interface that wraps the basic ReadAt method. </p>
+<p>ReadAt reads len(p) bytes into p starting at offset off in the underlying input source. It returns the number of bytes read (0 &lt;= n &lt;= len(p)) and any error encountered. </p>
+<p>When ReadAt returns n &lt; len(p), it returns a non-nil error explaining why more bytes were not returned. In this respect, ReadAt is stricter than Read. </p>
+<p>Even if ReadAt returns n &lt; len(p), it may use all of p as scratch space during the call. If some data is available but not len(p) bytes, ReadAt blocks until either all the data is available or an error occurs. In this respect ReadAt is different from Read. </p>
+<p>If the n = len(p) bytes returned by ReadAt are at the end of the input source, ReadAt may return either err == EOF or err == nil. </p>
+<p>If ReadAt is reading from an input source with a seek offset, ReadAt should not affect nor be affected by the underlying seek offset. </p>
+<p>Clients of ReadAt can execute parallel ReadAt calls on the same input source. </p>
+<p>Implementations must not retain p. </p>
+<pre data-language="go">type ReaderAt interface {
+    ReadAt(p []byte, off int64) (n int, err error)
+}</pre> <h2 id="ReaderFrom">type <span>ReaderFrom</span>  </h2> <p>ReaderFrom is the interface that wraps the ReadFrom method. </p>
+<p>ReadFrom reads data from r until EOF or error. The return value n is the number of bytes read. Any error except EOF encountered during the read is also returned. </p>
+<p>The <a href="#Copy">Copy</a> function uses <a href="#ReaderFrom">ReaderFrom</a> if available. </p>
+<pre data-language="go">type ReaderFrom interface {
+    ReadFrom(r Reader) (n int64, err error)
+}</pre> <h2 id="RuneReader">type <span>RuneReader</span>  </h2> <p>RuneReader is the interface that wraps the ReadRune method. </p>
+<p>ReadRune reads a single encoded Unicode character and returns the rune and its size in bytes. If no character is available, err will be set. </p>
+<pre data-language="go">type RuneReader interface {
+    ReadRune() (r rune, size int, err error)
+}</pre> <h2 id="RuneScanner">type <span>RuneScanner</span>  </h2> <p>RuneScanner is the interface that adds the UnreadRune method to the basic ReadRune method. </p>
+<p>UnreadRune causes the next call to ReadRune to return the last rune read. If the last operation was not a successful call to ReadRune, UnreadRune may return an error, unread the last rune read (or the rune prior to the last-unread rune), or (in implementations that support the <a href="#Seeker">Seeker</a> interface) seek to the start of the rune before the current offset. </p>
+<pre data-language="go">type RuneScanner interface {
+    RuneReader
+    UnreadRune() error
+}</pre> <h2 id="SectionReader">type <span>SectionReader</span>  </h2> <p>SectionReader implements Read, Seek, and ReadAt on a section of an underlying <a href="#ReaderAt">ReaderAt</a>. </p>
+<pre data-language="go">type SectionReader struct {
+    // contains filtered or unexported fields
+}
+</pre>    <h4 id="example_SectionReader"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+s := io.NewSectionReader(r, 5, 17)
+
+if _, err := io.Copy(os.Stdout, s); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">io.Reader stream
+</pre>   <h3 id="NewSectionReader">func <span>NewSectionReader</span>  </h3> <pre data-language="go">func NewSectionReader(r ReaderAt, off int64, n int64) *SectionReader</pre> <p>NewSectionReader returns a <a href="#SectionReader">SectionReader</a> that reads from r starting at offset off and stops with EOF after n bytes. </p>
+<h3 id="SectionReader.Outer">func (*SectionReader) <span>Outer</span>  <span title="Added in Go 1.22">1.22</span> </h3> <pre data-language="go">func (s *SectionReader) Outer() (r ReaderAt, off int64, n int64)</pre> <p>Outer returns the underlying <a href="#ReaderAt">ReaderAt</a> and offsets for the section. </p>
+<p>The returned values are the same that were passed to <a href="#NewSectionReader">NewSectionReader</a> when the <a href="#SectionReader">SectionReader</a> was created. </p>
+<h3 id="SectionReader.Read">func (*SectionReader) <span>Read</span>  </h3> <pre data-language="go">func (s *SectionReader) Read(p []byte) (n int, err error)</pre>    <h4 id="example_SectionReader_Read"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+s := io.NewSectionReader(r, 5, 17)
+
+buf := make([]byte, 9)
+if _, err := s.Read(buf); err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("%s\n", buf)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">io.Reader
+</pre>   <h3 id="SectionReader.ReadAt">func (*SectionReader) <span>ReadAt</span>  </h3> <pre data-language="go">func (s *SectionReader) ReadAt(p []byte, off int64) (n int, err error)</pre>    <h4 id="example_SectionReader_ReadAt"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+s := io.NewSectionReader(r, 5, 17)
+
+buf := make([]byte, 6)
+if _, err := s.ReadAt(buf, 10); err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("%s\n", buf)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">stream
+</pre>   <h3 id="SectionReader.Seek">func (*SectionReader) <span>Seek</span>  </h3> <pre data-language="go">func (s *SectionReader) Seek(offset int64, whence int) (int64, error)</pre>    <h4 id="example_SectionReader_Seek"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+s := io.NewSectionReader(r, 5, 17)
+
+if _, err := s.Seek(10, io.SeekStart); err != nil {
+    log.Fatal(err)
+}
+
+if _, err := io.Copy(os.Stdout, s); err != nil {
+    log.Fatal(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">stream
+</pre>   <h3 id="SectionReader.Size">func (*SectionReader) <span>Size</span>  </h3> <pre data-language="go">func (s *SectionReader) Size() int64</pre> <p>Size returns the size of the section in bytes. </p>   <h4 id="example_SectionReader_Size"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+s := io.NewSectionReader(r, 5, 17)
+
+fmt.Println(s.Size())
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">17
+</pre>   <h2 id="Seeker">type <span>Seeker</span>  </h2> <p>Seeker is the interface that wraps the basic Seek method. </p>
+<p>Seek sets the offset for the next Read or Write to offset, interpreted according to whence: <a href="#SeekStart">SeekStart</a> means relative to the start of the file, <a href="#SeekCurrent">SeekCurrent</a> means relative to the current offset, and <a href="#SeekEnd">SeekEnd</a> means relative to the end (for example, offset = -2 specifies the penultimate byte of the file). Seek returns the new offset relative to the start of the file or an error, if any. </p>
+<p>Seeking to an offset before the start of the file is an error. Seeking to any positive offset may be allowed, but if the new offset exceeds the size of the underlying object the behavior of subsequent I/O operations is implementation-dependent. </p>
+<pre data-language="go">type Seeker interface {
+    Seek(offset int64, whence int) (int64, error)
+}</pre> <h2 id="StringWriter">type <span>StringWriter</span>  <span title="Added in Go 1.12">1.12</span> </h2> <p>StringWriter is the interface that wraps the WriteString method. </p>
+<pre data-language="go">type StringWriter interface {
+    WriteString(s string) (n int, err error)
+}</pre> <h2 id="WriteCloser">type <span>WriteCloser</span>  </h2> <p>WriteCloser is the interface that groups the basic Write and Close methods. </p>
+<pre data-language="go">type WriteCloser interface {
+    Writer
+    Closer
+}</pre> <h2 id="WriteSeeker">type <span>WriteSeeker</span>  </h2> <p>WriteSeeker is the interface that groups the basic Write and Seek methods. </p>
+<pre data-language="go">type WriteSeeker interface {
+    Writer
+    Seeker
+}</pre> <h2 id="Writer">type <span>Writer</span>  </h2> <p>Writer is the interface that wraps the basic Write method. </p>
+<p>Write writes len(p) bytes from p to the underlying data stream. It returns the number of bytes written from p (0 &lt;= n &lt;= len(p)) and any error encountered that caused the write to stop early. Write must return a non-nil error if it returns n &lt; len(p). Write must not modify the slice data, even temporarily. </p>
+<p>Implementations must not retain p. </p>
+<pre data-language="go">type Writer interface {
+    Write(p []byte) (n int, err error)
+}</pre> <p>Discard is a <a href="#Writer">Writer</a> on which all Write calls succeed without doing anything. </p>
+<pre data-language="go">var Discard Writer = discard{}</pre> <h3 id="MultiWriter">func <span>MultiWriter</span>  </h3> <pre data-language="go">func MultiWriter(writers ...Writer) Writer</pre> <p>MultiWriter creates a writer that duplicates its writes to all the provided writers, similar to the Unix tee(1) command. </p>
+<p>Each write is written to each listed writer, one at a time. If a listed writer returns an error, that overall write operation stops and returns the error; it does not continue down the list. </p>   <h4 id="example_MultiWriter"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">r := strings.NewReader("some io.Reader stream to be read\n")
+
+var buf1, buf2 strings.Builder
+w := io.MultiWriter(&amp;buf1, &amp;buf2)
+
+if _, err := io.Copy(w, r); err != nil {
+    log.Fatal(err)
+}
+
+fmt.Print(buf1.String())
+fmt.Print(buf2.String())
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">some io.Reader stream to be read
+some io.Reader stream to be read
+</pre>   <h2 id="WriterAt">type <span>WriterAt</span>  </h2> <p>WriterAt is the interface that wraps the basic WriteAt method. </p>
+<p>WriteAt writes len(p) bytes from p to the underlying data stream at offset off. It returns the number of bytes written from p (0 &lt;= n &lt;= len(p)) and any error encountered that caused the write to stop early. WriteAt must return a non-nil error if it returns n &lt; len(p). </p>
+<p>If WriteAt is writing to a destination with a seek offset, WriteAt should not affect nor be affected by the underlying seek offset. </p>
+<p>Clients of WriteAt can execute parallel WriteAt calls on the same destination if the ranges do not overlap. </p>
+<p>Implementations must not retain p. </p>
+<pre data-language="go">type WriterAt interface {
+    WriteAt(p []byte, off int64) (n int, err error)
+}</pre> <h2 id="WriterTo">type <span>WriterTo</span>  </h2> <p>WriterTo is the interface that wraps the WriteTo method. </p>
+<p>WriteTo writes data to w until there's no more data to write or when an error occurs. The return value n is the number of bytes written. Any error encountered during the write is also returned. </p>
+<p>The Copy function uses WriterTo if available. </p>
+<pre data-language="go">type WriterTo interface {
+    WriteTo(w Writer) (n int64, err error)
+}</pre> <h2 id="pkg-subdirectories">Subdirectories</h2> <div class="pkg-dir"> <table> <tr> <th class="pkg-name">Name</th> <th class="pkg-synopsis">Synopsis</th> </tr> <tr> <td colspan="2"><a href="../index">..</a></td> </tr> <tr> <td class="pkg-name"> <a href="fs/index">fs</a> </td> <td class="pkg-synopsis"> Package fs defines basic interfaces to a file system. </td> </tr> <tr> <td class="pkg-name"> <a href="ioutil/index">ioutil</a> </td> <td class="pkg-synopsis"> Package ioutil implements some I/O utility functions. </td> </tr> </table> </div><div class="_attribution">
+  <p class="_attribution-p">
+    &copy; Google, Inc.<br>Licensed under the Creative Commons Attribution License 3.0.<br>
+    <a href="https://golang.org/pkg/io/" class="_attribution-link">http://golang.org/pkg/io/</a>
+  </p>
+</div>

--- a/provider/devdocs/__fixtures__/strconv/index.html
+++ b/provider/devdocs/__fixtures__/strconv/index.html
@@ -1,0 +1,449 @@
+<h1> Package strconv  </h1>     <ul id="short-nav">
+<li><code>import "strconv"</code></li>
+<li><a href="#pkg-overview" class="overviewLink">Overview</a></li>
+<li><a href="#pkg-index" class="indexLink">Index</a></li>
+<li><a href="#pkg-examples" class="examplesLink">Examples</a></li>
+</ul>     <h2 id="pkg-overview">Overview </h2> <p>Package strconv implements conversions to and from string representations of basic data types. </p>
+<h3 id="hdr-Numeric_Conversions">Numeric Conversions</h3> <p>The most common numeric conversions are Atoi (string to int) and Itoa (int to string). </p>
+<pre data-language="go">i, err := strconv.Atoi("-42")
+s := strconv.Itoa(-42)
+</pre> <p>These assume decimal and the Go int type. </p>
+<p><a href="#ParseBool">ParseBool</a>, <a href="#ParseFloat">ParseFloat</a>, <a href="#ParseInt">ParseInt</a>, and <a href="#ParseUint">ParseUint</a> convert strings to values: </p>
+<pre data-language="go">b, err := strconv.ParseBool("true")
+f, err := strconv.ParseFloat("3.1415", 64)
+i, err := strconv.ParseInt("-42", 10, 64)
+u, err := strconv.ParseUint("42", 10, 64)
+</pre> <p>The parse functions return the widest type (float64, int64, and uint64), but if the size argument specifies a narrower width the result can be converted to that narrower type without data loss: </p>
+<pre data-language="go">s := "2147483647" // biggest int32
+i64, err := strconv.ParseInt(s, 10, 32)
+...
+i := int32(i64)
+</pre> <p><a href="#FormatBool">FormatBool</a>, <a href="#FormatFloat">FormatFloat</a>, <a href="#FormatInt">FormatInt</a>, and <a href="#FormatUint">FormatUint</a> convert values to strings: </p>
+<pre data-language="go">s := strconv.FormatBool(true)
+s := strconv.FormatFloat(3.1415, 'E', -1, 64)
+s := strconv.FormatInt(-42, 16)
+s := strconv.FormatUint(42, 16)
+</pre> <p><a href="#AppendBool">AppendBool</a>, <a href="#AppendFloat">AppendFloat</a>, <a href="#AppendInt">AppendInt</a>, and <a href="#AppendUint">AppendUint</a> are similar but append the formatted value to a destination slice. </p>
+<h3 id="hdr-String_Conversions">String Conversions</h3> <p><a href="#Quote">Quote</a> and <a href="#QuoteToASCII">QuoteToASCII</a> convert strings to quoted Go string literals. The latter guarantees that the result is an ASCII string, by escaping any non-ASCII Unicode with \u: </p>
+<pre data-language="go">q := strconv.Quote("Hello, 世界")
+q := strconv.QuoteToASCII("Hello, 世界")
+</pre> <p><a href="#QuoteRune">QuoteRune</a> and <a href="#QuoteRuneToASCII">QuoteRuneToASCII</a> are similar but accept runes and return quoted Go rune literals. </p>
+<p><a href="#Unquote">Unquote</a> and <a href="#UnquoteChar">UnquoteChar</a> unquote Go string and rune literals. </p>     <h2 id="pkg-index">Index </h2>  <ul id="manual-nav">
+<li><a href="#pkg-constants">Constants</a></li>
+<li><a href="#pkg-variables">Variables</a></li>
+<li><a href="#AppendBool">func AppendBool(dst []byte, b bool) []byte</a></li>
+<li><a href="#AppendFloat">func AppendFloat(dst []byte, f float64, fmt byte, prec, bitSize int) []byte</a></li>
+<li><a href="#AppendInt">func AppendInt(dst []byte, i int64, base int) []byte</a></li>
+<li><a href="#AppendQuote">func AppendQuote(dst []byte, s string) []byte</a></li>
+<li><a href="#AppendQuoteRune">func AppendQuoteRune(dst []byte, r rune) []byte</a></li>
+<li><a href="#AppendQuoteRuneToASCII">func AppendQuoteRuneToASCII(dst []byte, r rune) []byte</a></li>
+<li><a href="#AppendQuoteRuneToGraphic">func AppendQuoteRuneToGraphic(dst []byte, r rune) []byte</a></li>
+<li><a href="#AppendQuoteToASCII">func AppendQuoteToASCII(dst []byte, s string) []byte</a></li>
+<li><a href="#AppendQuoteToGraphic">func AppendQuoteToGraphic(dst []byte, s string) []byte</a></li>
+<li><a href="#AppendUint">func AppendUint(dst []byte, i uint64, base int) []byte</a></li>
+<li><a href="#Atoi">func Atoi(s string) (int, error)</a></li>
+<li><a href="#CanBackquote">func CanBackquote(s string) bool</a></li>
+<li><a href="#FormatBool">func FormatBool(b bool) string</a></li>
+<li><a href="#FormatComplex">func FormatComplex(c complex128, fmt byte, prec, bitSize int) string</a></li>
+<li><a href="#FormatFloat">func FormatFloat(f float64, fmt byte, prec, bitSize int) string</a></li>
+<li><a href="#FormatInt">func FormatInt(i int64, base int) string</a></li>
+<li><a href="#FormatUint">func FormatUint(i uint64, base int) string</a></li>
+<li><a href="#IsGraphic">func IsGraphic(r rune) bool</a></li>
+<li><a href="#IsPrint">func IsPrint(r rune) bool</a></li>
+<li><a href="#Itoa">func Itoa(i int) string</a></li>
+<li><a href="#ParseBool">func ParseBool(str string) (bool, error)</a></li>
+<li><a href="#ParseComplex">func ParseComplex(s string, bitSize int) (complex128, error)</a></li>
+<li><a href="#ParseFloat">func ParseFloat(s string, bitSize int) (float64, error)</a></li>
+<li><a href="#ParseInt">func ParseInt(s string, base int, bitSize int) (i int64, err error)</a></li>
+<li><a href="#ParseUint">func ParseUint(s string, base int, bitSize int) (uint64, error)</a></li>
+<li><a href="#Quote">func Quote(s string) string</a></li>
+<li><a href="#QuoteRune">func QuoteRune(r rune) string</a></li>
+<li><a href="#QuoteRuneToASCII">func QuoteRuneToASCII(r rune) string</a></li>
+<li><a href="#QuoteRuneToGraphic">func QuoteRuneToGraphic(r rune) string</a></li>
+<li><a href="#QuoteToASCII">func QuoteToASCII(s string) string</a></li>
+<li><a href="#QuoteToGraphic">func QuoteToGraphic(s string) string</a></li>
+<li><a href="#QuotedPrefix">func QuotedPrefix(s string) (string, error)</a></li>
+<li><a href="#Unquote">func Unquote(s string) (string, error)</a></li>
+<li><a href="#UnquoteChar">func UnquoteChar(s string, quote byte) (value rune, multibyte bool, tail string, err error)</a></li>
+<li><a href="#NumError">type NumError</a></li>
+<li> <a href="#NumError.Error">func (e *NumError) Error() string</a>
+</li>
+<li> <a href="#NumError.Unwrap">func (e *NumError) Unwrap() error</a>
+</li>
+</ul> <div id="pkg-examples"> <h3>Examples</h3>  <dl> <dd><a class="exampleLink" href="#example_AppendBool">AppendBool</a></dd> <dd><a class="exampleLink" href="#example_AppendFloat">AppendFloat</a></dd> <dd><a class="exampleLink" href="#example_AppendInt">AppendInt</a></dd> <dd><a class="exampleLink" href="#example_AppendQuote">AppendQuote</a></dd> <dd><a class="exampleLink" href="#example_AppendQuoteRune">AppendQuoteRune</a></dd> <dd><a class="exampleLink" href="#example_AppendQuoteRuneToASCII">AppendQuoteRuneToASCII</a></dd> <dd><a class="exampleLink" href="#example_AppendQuoteToASCII">AppendQuoteToASCII</a></dd> <dd><a class="exampleLink" href="#example_AppendUint">AppendUint</a></dd> <dd><a class="exampleLink" href="#example_Atoi">Atoi</a></dd> <dd><a class="exampleLink" href="#example_CanBackquote">CanBackquote</a></dd> <dd><a class="exampleLink" href="#example_FormatBool">FormatBool</a></dd> <dd><a class="exampleLink" href="#example_FormatFloat">FormatFloat</a></dd> <dd><a class="exampleLink" href="#example_FormatInt">FormatInt</a></dd> <dd><a class="exampleLink" href="#example_FormatUint">FormatUint</a></dd> <dd><a class="exampleLink" href="#example_IsGraphic">IsGraphic</a></dd> <dd><a class="exampleLink" href="#example_IsPrint">IsPrint</a></dd> <dd><a class="exampleLink" href="#example_Itoa">Itoa</a></dd> <dd><a class="exampleLink" href="#example_NumError">NumError</a></dd> <dd><a class="exampleLink" href="#example_ParseBool">ParseBool</a></dd> <dd><a class="exampleLink" href="#example_ParseFloat">ParseFloat</a></dd> <dd><a class="exampleLink" href="#example_ParseInt">ParseInt</a></dd> <dd><a class="exampleLink" href="#example_ParseUint">ParseUint</a></dd> <dd><a class="exampleLink" href="#example_Quote">Quote</a></dd> <dd><a class="exampleLink" href="#example_QuoteRune">QuoteRune</a></dd> <dd><a class="exampleLink" href="#example_QuoteRuneToASCII">QuoteRuneToASCII</a></dd> <dd><a class="exampleLink" href="#example_QuoteRuneToGraphic">QuoteRuneToGraphic</a></dd> <dd><a class="exampleLink" href="#example_QuoteToASCII">QuoteToASCII</a></dd> <dd><a class="exampleLink" href="#example_QuoteToGraphic">QuoteToGraphic</a></dd> <dd><a class="exampleLink" href="#example_QuotedPrefix">QuotedPrefix</a></dd> <dd><a class="exampleLink" href="#example_Unquote">Unquote</a></dd> <dd><a class="exampleLink" href="#example_UnquoteChar">UnquoteChar</a></dd> </dl> </div> <h3>Package files</h3> <p>  <span>atob.go</span> <span>atoc.go</span> <span>atof.go</span> <span>atoi.go</span> <span>bytealg.go</span> <span>ctoa.go</span> <span>decimal.go</span> <span>doc.go</span> <span>eisel_lemire.go</span> <span>ftoa.go</span> <span>ftoaryu.go</span> <span>isprint.go</span> <span>itoa.go</span> <span>quote.go</span>  </p>   <h2 id="pkg-constants">Constants</h2> <p>IntSize is the size in bits of an int or uint value. </p>
+<pre data-language="go">const IntSize = intSize</pre> <h2 id="pkg-variables">Variables</h2> <p>ErrRange indicates that a value is out of range for the target type. </p>
+<pre data-language="go">var ErrRange = errors.New("value out of range")</pre> <p>ErrSyntax indicates that a value does not have the right syntax for the target type. </p>
+<pre data-language="go">var ErrSyntax = errors.New("invalid syntax")</pre> <h2 id="AppendBool">func <span>AppendBool</span>  </h2> <pre data-language="go">func AppendBool(dst []byte, b bool) []byte</pre> <p>AppendBool appends "true" or "false", according to the value of b, to dst and returns the extended buffer. </p>   <h4 id="example_AppendBool"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b := []byte("bool:")
+b = strconv.AppendBool(b, true)
+fmt.Println(string(b))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">bool:true
+</pre>   <h2 id="AppendFloat">func <span>AppendFloat</span>  </h2> <pre data-language="go">func AppendFloat(dst []byte, f float64, fmt byte, prec, bitSize int) []byte</pre> <p>AppendFloat appends the string form of the floating-point number f, as generated by FormatFloat, to dst and returns the extended buffer. </p>   <h4 id="example_AppendFloat"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b32 := []byte("float32:")
+b32 = strconv.AppendFloat(b32, 3.1415926535, 'E', -1, 32)
+fmt.Println(string(b32))
+
+b64 := []byte("float64:")
+b64 = strconv.AppendFloat(b64, 3.1415926535, 'E', -1, 64)
+fmt.Println(string(b64))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">float32:3.1415927E+00
+float64:3.1415926535E+00
+</pre>   <h2 id="AppendInt">func <span>AppendInt</span>  </h2> <pre data-language="go">func AppendInt(dst []byte, i int64, base int) []byte</pre> <p>AppendInt appends the string form of the integer i, as generated by FormatInt, to dst and returns the extended buffer. </p>   <h4 id="example_AppendInt"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b10 := []byte("int (base 10):")
+b10 = strconv.AppendInt(b10, -42, 10)
+fmt.Println(string(b10))
+
+b16 := []byte("int (base 16):")
+b16 = strconv.AppendInt(b16, -42, 16)
+fmt.Println(string(b16))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">int (base 10):-42
+int (base 16):-2a
+</pre>   <h2 id="AppendQuote">func <span>AppendQuote</span>  </h2> <pre data-language="go">func AppendQuote(dst []byte, s string) []byte</pre> <p>AppendQuote appends a double-quoted Go string literal representing s, as generated by Quote, to dst and returns the extended buffer. </p>   <h4 id="example_AppendQuote"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b := []byte("quote:")
+b = strconv.AppendQuote(b, `"Fran &amp; Freddie's Diner"`)
+fmt.Println(string(b))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">quote:"\"Fran &amp; Freddie's Diner\""
+</pre>   <h2 id="AppendQuoteRune">func <span>AppendQuoteRune</span>  </h2> <pre data-language="go">func AppendQuoteRune(dst []byte, r rune) []byte</pre> <p>AppendQuoteRune appends a single-quoted Go character literal representing the rune, as generated by QuoteRune, to dst and returns the extended buffer. </p>   <h4 id="example_AppendQuoteRune"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b := []byte("rune:")
+b = strconv.AppendQuoteRune(b, '☺')
+fmt.Println(string(b))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">rune:'☺'
+</pre>   <h2 id="AppendQuoteRuneToASCII">func <span>AppendQuoteRuneToASCII</span>  </h2> <pre data-language="go">func AppendQuoteRuneToASCII(dst []byte, r rune) []byte</pre> <p>AppendQuoteRuneToASCII appends a single-quoted Go character literal representing the rune, as generated by QuoteRuneToASCII, to dst and returns the extended buffer. </p>   <h4 id="example_AppendQuoteRuneToASCII"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b := []byte("rune (ascii):")
+b = strconv.AppendQuoteRuneToASCII(b, '☺')
+fmt.Println(string(b))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">rune (ascii):'\u263a'
+</pre>   <h2 id="AppendQuoteRuneToGraphic">func <span>AppendQuoteRuneToGraphic</span>  <span title="Added in Go 1.6">1.6</span> </h2> <pre data-language="go">func AppendQuoteRuneToGraphic(dst []byte, r rune) []byte</pre> <p>AppendQuoteRuneToGraphic appends a single-quoted Go character literal representing the rune, as generated by QuoteRuneToGraphic, to dst and returns the extended buffer. </p>
+<h2 id="AppendQuoteToASCII">func <span>AppendQuoteToASCII</span>  </h2> <pre data-language="go">func AppendQuoteToASCII(dst []byte, s string) []byte</pre> <p>AppendQuoteToASCII appends a double-quoted Go string literal representing s, as generated by QuoteToASCII, to dst and returns the extended buffer. </p>   <h4 id="example_AppendQuoteToASCII"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b := []byte("quote (ascii):")
+b = strconv.AppendQuoteToASCII(b, `"Fran &amp; Freddie's Diner"`)
+fmt.Println(string(b))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">quote (ascii):"\"Fran &amp; Freddie's Diner\""
+</pre>   <h2 id="AppendQuoteToGraphic">func <span>AppendQuoteToGraphic</span>  <span title="Added in Go 1.6">1.6</span> </h2> <pre data-language="go">func AppendQuoteToGraphic(dst []byte, s string) []byte</pre> <p>AppendQuoteToGraphic appends a double-quoted Go string literal representing s, as generated by QuoteToGraphic, to dst and returns the extended buffer. </p>
+<h2 id="AppendUint">func <span>AppendUint</span>  </h2> <pre data-language="go">func AppendUint(dst []byte, i uint64, base int) []byte</pre> <p>AppendUint appends the string form of the unsigned integer i, as generated by FormatUint, to dst and returns the extended buffer. </p>   <h4 id="example_AppendUint"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">b10 := []byte("uint (base 10):")
+b10 = strconv.AppendUint(b10, 42, 10)
+fmt.Println(string(b10))
+
+b16 := []byte("uint (base 16):")
+b16 = strconv.AppendUint(b16, 42, 16)
+fmt.Println(string(b16))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">uint (base 10):42
+uint (base 16):2a
+</pre>   <h2 id="Atoi">func <span>Atoi</span>  </h2> <pre data-language="go">func Atoi(s string) (int, error)</pre> <p>Atoi is equivalent to ParseInt(s, 10, 0), converted to type int. </p>   <h4 id="example_Atoi"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := "10"
+if s, err := strconv.Atoi(v); err == nil {
+    fmt.Printf("%T, %v", s, s)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">int, 10
+</pre>   <h2 id="CanBackquote">func <span>CanBackquote</span>  </h2> <pre data-language="go">func CanBackquote(s string) bool</pre> <p>CanBackquote reports whether the string s can be represented unchanged as a single-line backquoted string without control characters other than tab. </p>   <h4 id="example_CanBackquote"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">fmt.Println(strconv.CanBackquote("Fran &amp; Freddie's Diner ☺"))
+fmt.Println(strconv.CanBackquote("`can't backquote this`"))
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">true
+false
+</pre>   <h2 id="FormatBool">func <span>FormatBool</span>  </h2> <pre data-language="go">func FormatBool(b bool) string</pre> <p>FormatBool returns "true" or "false" according to the value of b. </p>   <h4 id="example_FormatBool"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := true
+s := strconv.FormatBool(v)
+fmt.Printf("%T, %v\n", s, s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">string, true
+</pre>   <h2 id="FormatComplex">func <span>FormatComplex</span>  <span title="Added in Go 1.15">1.15</span> </h2> <pre data-language="go">func FormatComplex(c complex128, fmt byte, prec, bitSize int) string</pre> <p>FormatComplex converts the complex number c to a string of the form (a+bi) where a and b are the real and imaginary parts, formatted according to the format fmt and precision prec. </p>
+<p>The format fmt and precision prec have the same meaning as in FormatFloat. It rounds the result assuming that the original was obtained from a complex value of bitSize bits, which must be 64 for complex64 and 128 for complex128. </p>
+<h2 id="FormatFloat">func <span>FormatFloat</span>  </h2> <pre data-language="go">func FormatFloat(f float64, fmt byte, prec, bitSize int) string</pre> <p>FormatFloat converts the floating-point number f to a string, according to the format fmt and precision prec. It rounds the result assuming that the original was obtained from a floating-point value of bitSize bits (32 for float32, 64 for float64). </p>
+<p>The format fmt is one of 'b' (-ddddp±ddd, a binary exponent), 'e' (-d.dddde±dd, a decimal exponent), 'E' (-d.ddddE±dd, a decimal exponent), 'f' (-ddd.dddd, no exponent), 'g' ('e' for large exponents, 'f' otherwise), 'G' ('E' for large exponents, 'f' otherwise), 'x' (-0xd.ddddp±ddd, a hexadecimal fraction and binary exponent), or 'X' (-0Xd.ddddP±ddd, a hexadecimal fraction and binary exponent). </p>
+<p>The precision prec controls the number of digits (excluding the exponent) printed by the 'e', 'E', 'f', 'g', 'G', 'x', and 'X' formats. For 'e', 'E', 'f', 'x', and 'X', it is the number of digits after the decimal point. For 'g' and 'G' it is the maximum number of significant digits (trailing zeros are removed). The special precision -1 uses the smallest number of digits necessary such that ParseFloat will return f exactly. </p>   <h4 id="example_FormatFloat"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := 3.1415926535
+
+s32 := strconv.FormatFloat(v, 'E', -1, 32)
+fmt.Printf("%T, %v\n", s32, s32)
+
+s64 := strconv.FormatFloat(v, 'E', -1, 64)
+fmt.Printf("%T, %v\n", s64, s64)
+
+// fmt.Println uses these arguments to print floats
+fmt64 := strconv.FormatFloat(v, 'g', -1, 64)
+fmt.Printf("%T, %v\n", fmt64, fmt64)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">string, 3.1415927E+00
+string, 3.1415926535E+00
+string, 3.1415926535
+</pre>   <h2 id="FormatInt">func <span>FormatInt</span>  </h2> <pre data-language="go">func FormatInt(i int64, base int) string</pre> <p>FormatInt returns the string representation of i in the given base, for 2 &lt;= base &lt;= 36. The result uses the lower-case letters 'a' to 'z' for digit values &gt;= 10. </p>   <h4 id="example_FormatInt"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := int64(-42)
+
+s10 := strconv.FormatInt(v, 10)
+fmt.Printf("%T, %v\n", s10, s10)
+
+s16 := strconv.FormatInt(v, 16)
+fmt.Printf("%T, %v\n", s16, s16)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">string, -42
+string, -2a
+</pre>   <h2 id="FormatUint">func <span>FormatUint</span>  </h2> <pre data-language="go">func FormatUint(i uint64, base int) string</pre> <p>FormatUint returns the string representation of i in the given base, for 2 &lt;= base &lt;= 36. The result uses the lower-case letters 'a' to 'z' for digit values &gt;= 10. </p>   <h4 id="example_FormatUint"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := uint64(42)
+
+s10 := strconv.FormatUint(v, 10)
+fmt.Printf("%T, %v\n", s10, s10)
+
+s16 := strconv.FormatUint(v, 16)
+fmt.Printf("%T, %v\n", s16, s16)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">string, 42
+string, 2a
+</pre>   <h2 id="IsGraphic">func <span>IsGraphic</span>  <span title="Added in Go 1.6">1.6</span> </h2> <pre data-language="go">func IsGraphic(r rune) bool</pre> <p>IsGraphic reports whether the rune is defined as a Graphic by Unicode. Such characters include letters, marks, numbers, punctuation, symbols, and spaces, from categories L, M, N, P, S, and Zs. </p>   <h4 id="example_IsGraphic"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">shamrock := strconv.IsGraphic('☘')
+fmt.Println(shamrock)
+
+a := strconv.IsGraphic('a')
+fmt.Println(a)
+
+bel := strconv.IsGraphic('\007')
+fmt.Println(bel)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">true
+true
+false
+</pre>   <h2 id="IsPrint">func <span>IsPrint</span>  </h2> <pre data-language="go">func IsPrint(r rune) bool</pre> <p>IsPrint reports whether the rune is defined as printable by Go, with the same definition as unicode.IsPrint: letters, numbers, punctuation, symbols and ASCII space. </p>   <h4 id="example_IsPrint"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">c := strconv.IsPrint('\u263a')
+fmt.Println(c)
+
+bel := strconv.IsPrint('\007')
+fmt.Println(bel)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">true
+false
+</pre>   <h2 id="Itoa">func <span>Itoa</span>  </h2> <pre data-language="go">func Itoa(i int) string</pre> <p>Itoa is equivalent to FormatInt(int64(i), 10). </p>   <h4 id="example_Itoa"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">i := 10
+s := strconv.Itoa(i)
+fmt.Printf("%T, %v\n", s, s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">string, 10
+</pre>   <h2 id="ParseBool">func <span>ParseBool</span>  </h2> <pre data-language="go">func ParseBool(str string) (bool, error)</pre> <p>ParseBool returns the boolean value represented by the string. It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other value returns an error. </p>   <h4 id="example_ParseBool"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := "true"
+if s, err := strconv.ParseBool(v); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">bool, true
+</pre>   <h2 id="ParseComplex">func <span>ParseComplex</span>  <span title="Added in Go 1.15">1.15</span> </h2> <pre data-language="go">func ParseComplex(s string, bitSize int) (complex128, error)</pre> <p>ParseComplex converts the string s to a complex number with the precision specified by bitSize: 64 for complex64, or 128 for complex128. When bitSize=64, the result still has type complex128, but it will be convertible to complex64 without changing its value. </p>
+<p>The number represented by s must be of the form N, Ni, or N±Ni, where N stands for a floating-point number as recognized by ParseFloat, and i is the imaginary component. If the second N is unsigned, a + sign is required between the two components as indicated by the ±. If the second N is NaN, only a + sign is accepted. The form may be parenthesized and cannot contain any spaces. The resulting complex number consists of the two components converted by ParseFloat. </p>
+<p>The errors that ParseComplex returns have concrete type *NumError and include err.Num = s. </p>
+<p>If s is not syntactically well-formed, ParseComplex returns err.Err = ErrSyntax. </p>
+<p>If s is syntactically well-formed but either component is more than 1/2 ULP away from the largest floating point number of the given component's size, ParseComplex returns err.Err = ErrRange and c = ±Inf for the respective component. </p>
+<h2 id="ParseFloat">func <span>ParseFloat</span>  </h2> <pre data-language="go">func ParseFloat(s string, bitSize int) (float64, error)</pre> <p>ParseFloat converts the string s to a floating-point number with the precision specified by bitSize: 32 for float32, or 64 for float64. When bitSize=32, the result still has type float64, but it will be convertible to float32 without changing its value. </p>
+<p>ParseFloat accepts decimal and hexadecimal floating-point numbers as defined by the Go syntax for <a href="https://go.dev/ref/spec#Floating-point_literals">floating-point literals</a>. If s is well-formed and near a valid floating-point number, ParseFloat returns the nearest floating-point number rounded using IEEE754 unbiased rounding. (Parsing a hexadecimal floating-point value only rounds when there are more bits in the hexadecimal representation than will fit in the mantissa.) </p>
+<p>The errors that ParseFloat returns have concrete type *NumError and include err.Num = s. </p>
+<p>If s is not syntactically well-formed, ParseFloat returns err.Err = ErrSyntax. </p>
+<p>If s is syntactically well-formed but is more than 1/2 ULP away from the largest floating point number of the given size, ParseFloat returns f = ±Inf, err.Err = ErrRange. </p>
+<p>ParseFloat recognizes the string "NaN", and the (possibly signed) strings "Inf" and "Infinity" as their respective special floating point values. It ignores case when matching. </p>   <h4 id="example_ParseFloat"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := "3.1415926535"
+if s, err := strconv.ParseFloat(v, 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat(v, 64); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat("NaN", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+// ParseFloat is case insensitive
+if s, err := strconv.ParseFloat("nan", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat("inf", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat("+Inf", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat("-Inf", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat("-0", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseFloat("+0", 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">float64, 3.1415927410125732
+float64, 3.1415926535
+float64, NaN
+float64, NaN
+float64, +Inf
+float64, +Inf
+float64, -Inf
+float64, -0
+float64, 0
+</pre>   <h2 id="ParseInt">func <span>ParseInt</span>  </h2> <pre data-language="go">func ParseInt(s string, base int, bitSize int) (i int64, err error)</pre> <p>ParseInt interprets a string s in the given base (0, 2 to 36) and bit size (0 to 64) and returns the corresponding value i. </p>
+<p>The string may begin with a leading sign: "+" or "-". </p>
+<p>If the base argument is 0, the true base is implied by the string's prefix following the sign (if present): 2 for "0b", 8 for "0" or "0o", 16 for "0x", and 10 otherwise. Also, for argument base 0 only, underscore characters are permitted as defined by the Go syntax for <a href="https://go.dev/ref/spec#Integer_literals">integer literals</a>. </p>
+<p>The bitSize argument specifies the integer type that the result must fit into. Bit sizes 0, 8, 16, 32, and 64 correspond to int, int8, int16, int32, and int64. If bitSize is below 0 or above 64, an error is returned. </p>
+<p>The errors that ParseInt returns have concrete type *NumError and include err.Num = s. If s is empty or contains invalid digits, err.Err = ErrSyntax and the returned value is 0; if the value corresponding to s cannot be represented by a signed integer of the given size, err.Err = ErrRange and the returned value is the maximum magnitude integer of the appropriate bitSize and sign. </p>   <h4 id="example_ParseInt"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v32 := "-354634382"
+if s, err := strconv.ParseInt(v32, 10, 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseInt(v32, 16, 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+
+v64 := "-3546343826724305832"
+if s, err := strconv.ParseInt(v64, 10, 64); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseInt(v64, 16, 64); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">int64, -354634382
+int64, -3546343826724305832
+</pre>   <h2 id="ParseUint">func <span>ParseUint</span>  </h2> <pre data-language="go">func ParseUint(s string, base int, bitSize int) (uint64, error)</pre> <p>ParseUint is like ParseInt but for unsigned numbers. </p>
+<p>A sign prefix is not permitted. </p>   <h4 id="example_ParseUint"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v := "42"
+if s, err := strconv.ParseUint(v, 10, 32); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+if s, err := strconv.ParseUint(v, 10, 64); err == nil {
+    fmt.Printf("%T, %v\n", s, s)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">uint64, 42
+uint64, 42
+</pre>   <h2 id="Quote">func <span>Quote</span>  </h2> <pre data-language="go">func Quote(s string) string</pre> <p>Quote returns a double-quoted Go string literal representing s. The returned string uses Go escape sequences (\t, \n, \xFF, \u0100) for control characters and non-printable characters as defined by IsPrint. </p>   <h4 id="example_Quote"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">// This string literal contains a tab character.
+s := strconv.Quote(`"Fran &amp; Freddie's Diner	☺"`)
+fmt.Println(s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">"\"Fran &amp; Freddie's Diner\t☺\""
+</pre>   <h2 id="QuoteRune">func <span>QuoteRune</span>  </h2> <pre data-language="go">func QuoteRune(r rune) string</pre> <p>QuoteRune returns a single-quoted Go character literal representing the rune. The returned string uses Go escape sequences (\t, \n, \xFF, \u0100) for control characters and non-printable characters as defined by IsPrint. If r is not a valid Unicode code point, it is interpreted as the Unicode replacement character U+FFFD. </p>   <h4 id="example_QuoteRune"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">s := strconv.QuoteRune('☺')
+fmt.Println(s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">'☺'
+</pre>   <h2 id="QuoteRuneToASCII">func <span>QuoteRuneToASCII</span>  </h2> <pre data-language="go">func QuoteRuneToASCII(r rune) string</pre> <p>QuoteRuneToASCII returns a single-quoted Go character literal representing the rune. The returned string uses Go escape sequences (\t, \n, \xFF, \u0100) for non-ASCII characters and non-printable characters as defined by IsPrint. If r is not a valid Unicode code point, it is interpreted as the Unicode replacement character U+FFFD. </p>   <h4 id="example_QuoteRuneToASCII"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">s := strconv.QuoteRuneToASCII('☺')
+fmt.Println(s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">'\u263a'
+</pre>   <h2 id="QuoteRuneToGraphic">func <span>QuoteRuneToGraphic</span>  <span title="Added in Go 1.6">1.6</span> </h2> <pre data-language="go">func QuoteRuneToGraphic(r rune) string</pre> <p>QuoteRuneToGraphic returns a single-quoted Go character literal representing the rune. If the rune is not a Unicode graphic character, as defined by IsGraphic, the returned string will use a Go escape sequence (\t, \n, \xFF, \u0100). If r is not a valid Unicode code point, it is interpreted as the Unicode replacement character U+FFFD. </p>   <h4 id="example_QuoteRuneToGraphic"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">s := strconv.QuoteRuneToGraphic('☺')
+fmt.Println(s)
+
+s = strconv.QuoteRuneToGraphic('\u263a')
+fmt.Println(s)
+
+s = strconv.QuoteRuneToGraphic('\u000a')
+fmt.Println(s)
+
+s = strconv.QuoteRuneToGraphic('	') // tab character
+fmt.Println(s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">'☺'
+'☺'
+'\n'
+'\t'
+</pre>   <h2 id="QuoteToASCII">func <span>QuoteToASCII</span>  </h2> <pre data-language="go">func QuoteToASCII(s string) string</pre> <p>QuoteToASCII returns a double-quoted Go string literal representing s. The returned string uses Go escape sequences (\t, \n, \xFF, \u0100) for non-ASCII characters and non-printable characters as defined by IsPrint. </p>   <h4 id="example_QuoteToASCII"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">// This string literal contains a tab character.
+s := strconv.QuoteToASCII(`"Fran &amp; Freddie's Diner	☺"`)
+fmt.Println(s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">"\"Fran &amp; Freddie's Diner\t\u263a\""
+</pre>   <h2 id="QuoteToGraphic">func <span>QuoteToGraphic</span>  <span title="Added in Go 1.6">1.6</span> </h2> <pre data-language="go">func QuoteToGraphic(s string) string</pre> <p>QuoteToGraphic returns a double-quoted Go string literal representing s. The returned string leaves Unicode graphic characters, as defined by IsGraphic, unchanged and uses Go escape sequences (\t, \n, \xFF, \u0100) for non-graphic characters. </p>   <h4 id="example_QuoteToGraphic"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">s := strconv.QuoteToGraphic("☺")
+fmt.Println(s)
+
+// This string literal contains a tab character.
+s = strconv.QuoteToGraphic("This is a \u263a	\u000a")
+fmt.Println(s)
+
+s = strconv.QuoteToGraphic(`" This is a ☺ \n "`)
+fmt.Println(s)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">"☺"
+"This is a ☺\t\n"
+"\" This is a ☺ \\n \""
+</pre>   <h2 id="QuotedPrefix">func <span>QuotedPrefix</span>  <span title="Added in Go 1.17">1.17</span> </h2> <pre data-language="go">func QuotedPrefix(s string) (string, error)</pre> <p>QuotedPrefix returns the quoted string (as understood by Unquote) at the prefix of s. If s does not start with a valid quoted string, QuotedPrefix returns an error. </p>   <h4 id="example_QuotedPrefix"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">s, err := strconv.QuotedPrefix("not a quoted string")
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.QuotedPrefix("\"double-quoted string\" with trailing text")
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.QuotedPrefix("`or backquoted` with more trailing text")
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.QuotedPrefix("'\u263a' is also okay")
+fmt.Printf("%q, %v\n", s, err)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">"", invalid syntax
+"\"double-quoted string\"", &lt;nil&gt;
+"`or backquoted`", &lt;nil&gt;
+"'☺'", &lt;nil&gt;
+</pre>   <h2 id="Unquote">func <span>Unquote</span>  </h2> <pre data-language="go">func Unquote(s string) (string, error)</pre> <p>Unquote interprets s as a single-quoted, double-quoted, or backquoted Go string literal, returning the string value that s quotes. (If s is single-quoted, it would be a Go character literal; Unquote returns the corresponding one-character string.) </p>   <h4 id="example_Unquote"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">s, err := strconv.Unquote("You can't unquote a string without quotes")
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.Unquote("\"The string must be either double-quoted\"")
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.Unquote("`or backquoted.`")
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.Unquote("'\u263a'") // single character only allowed in single quotes
+fmt.Printf("%q, %v\n", s, err)
+s, err = strconv.Unquote("'\u2639\u2639'")
+fmt.Printf("%q, %v\n", s, err)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">"", invalid syntax
+"The string must be either double-quoted", &lt;nil&gt;
+"or backquoted.", &lt;nil&gt;
+"☺", &lt;nil&gt;
+"", invalid syntax
+</pre>   <h2 id="UnquoteChar">func <span>UnquoteChar</span>  </h2> <pre data-language="go">func UnquoteChar(s string, quote byte) (value rune, multibyte bool, tail string, err error)</pre> <p>UnquoteChar decodes the first character or byte in the escaped string or character literal represented by the string s. It returns four values: </p>
+<ol> <li>value, the decoded Unicode code point or byte value; </li>
+<li>multibyte, a boolean indicating whether the decoded character requires a multibyte UTF-8 representation; </li>
+<li>tail, the remainder of the string after the character; and </li>
+<li>an error that will be nil if the character is syntactically valid. </li>
+</ol> <p>The second argument, quote, specifies the type of literal being parsed and therefore which escaped quote character is permitted. If set to a single quote, it permits the sequence \' and disallows unescaped '. If set to a double quote, it permits \" and disallows unescaped ". If set to zero, it does not permit either escape and allows both quote characters to appear unescaped. </p>   <h4 id="example_UnquoteChar"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">v, mb, t, err := strconv.UnquoteChar(`\"Fran &amp; Freddie's Diner\"`, '"')
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("value:", string(v))
+fmt.Println("multibyte:", mb)
+fmt.Println("tail:", t)
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">value: "
+multibyte: false
+tail: Fran &amp; Freddie's Diner\"
+</pre>   <h2 id="NumError">type <span>NumError</span>  </h2> <p>A NumError records a failed conversion. </p>
+<pre data-language="go">type NumError struct {
+    Func string // the failing function (ParseBool, ParseInt, ParseUint, ParseFloat, ParseComplex)
+    Num  string // the input
+    Err  error  // the reason the conversion failed (e.g. ErrRange, ErrSyntax, etc.)
+}
+</pre>    <h4 id="example_NumError"> <span class="text">Example</span>
+</h4> <p>Code:</p> <pre class="code" data-language="go">str := "Not a number"
+if _, err := strconv.ParseFloat(str, 64); err != nil {
+    e := err.(*strconv.NumError)
+    fmt.Println("Func:", e.Func)
+    fmt.Println("Num:", e.Num)
+    fmt.Println("Err:", e.Err)
+    fmt.Println(err)
+}
+
+</pre> <p>Output:</p> <pre class="output" data-language="go">Func: ParseFloat
+Num: Not a number
+Err: invalid syntax
+strconv.ParseFloat: parsing "Not a number": invalid syntax
+</pre>   <h3 id="NumError.Error">func (*NumError) <span>Error</span>  </h3> <pre data-language="go">func (e *NumError) Error() string</pre> <h3 id="NumError.Unwrap">func (*NumError) <span>Unwrap</span>  <span title="Added in Go 1.14">1.14</span> </h3> <pre data-language="go">func (e *NumError) Unwrap() error</pre><div class="_attribution">
+  <p class="_attribution-p">
+    &copy; Google, Inc.<br>Licensed under the Creative Commons Attribution License 3.0.<br>
+    <a href="https://golang.org/pkg/strconv/" class="_attribution-link">http://golang.org/pkg/strconv/</a>
+  </p>
+</div>

--- a/provider/devdocs/devdocs.ts
+++ b/provider/devdocs/devdocs.ts
@@ -1,0 +1,55 @@
+import url from 'url'
+import fs from 'fs/promises'
+
+/** Format of the file found at a location like https://devdocs.io/docs/go/index.json */
+interface Index {
+    entries: {
+        /** @example "adler32.Checksum()" */
+        name: string
+        /** @example "hash/adler32/index#Checksum" */
+        path: string
+        /** @example "hash" */
+        type: string
+    }[]
+    types: {
+        /** @example "archive" */
+        name: string
+        /** @example 56 */
+        count: number
+        /** @example "archive" */
+        slug: string
+    }[]
+}
+
+export async function fetchIndex(devdocsURL: string): Promise<Index> {
+    const baseURL = new URL(devdocsURL)
+    if (baseURL.protocol === 'file:') {
+        const indexURL = new URL('index.json', baseURL)
+        return JSON.parse(await fs.readFile(url.fileURLToPath(indexURL), 'utf8'))
+    }
+
+    // Transform path of baseURL from /{slug}/ to /docs/{slug}/index.json
+    const indexURL = new URL(`/docs${baseURL.pathname}index.json`, baseURL)
+    const response = await fetch(indexURL.toString())
+    const index = JSON.parse(await response.text())
+
+    return index
+}
+
+export async function fetchDoc(docURL: string): Promise<{ content: string; hash: string }> {
+    const contentURL = new URL(docURL)
+    contentURL.pathname = contentURL.pathname + '.html'
+
+    const hash = contentURL.hash
+    contentURL.hash = ''
+
+    if (contentURL.protocol === 'file:') {
+        return { hash, content: await fs.readFile(url.fileURLToPath(contentURL), 'utf8') }
+    }
+
+    // Needs to be translated into something like https://documents.devdocs.io/go/hash/adler32/index.html
+    contentURL.host = 'documents.devdocs.io'
+
+    const response = await fetch(contentURL.toString())
+    return { hash, content: await response.text() }
+}

--- a/provider/devdocs/index.test.ts
+++ b/provider/devdocs/index.test.ts
@@ -1,0 +1,113 @@
+import path from 'path'
+import url from 'url'
+import type { Item, Mention, MentionsParams } from '@openctx/provider'
+import { describe, expect, test } from 'vitest'
+import devdocs, { type Settings } from './index.js'
+
+// We only run this if INTEGRATION is true to avoid flakiness.
+const INTEGRATION = !!process.env.INTEGRATION
+
+describe('devdocs', () => {
+    test('test page type', async () => {
+        const fixturesDir = path.join(__dirname, '__fixtures__')
+        const settings = {
+            urls: [url.pathToFileURL(fixturesDir).toString()],
+        }
+
+        const mentionPath = path.join(fixturesDir, 'strconv', 'index')
+        const item = await expectMentionItem({ query: 'strconv' }, settings, {
+            title: 'strconv',
+            uri: url.pathToFileURL(mentionPath).toString(),
+        })
+        expect(item.ai?.content).toContain(
+            'Package strconv implements conversions to and from string representations of basic data types.'
+        )
+    })
+    test.runIf(INTEGRATION)('integration test page type', async () => {
+        const settings = {
+            urls: ['https://devdocs.io/go/'],
+        }
+
+        const item = await expectMentionItem({ query: 'strconv' }, settings, {
+            title: 'strconv',
+            uri: 'https://devdocs.io/go/strconv/index',
+        })
+        expect(item.ai?.content).toContain(
+            'Package strconv implements conversions to and from string representations of basic data types.'
+        )
+    })
+
+    test('test hash type', async () => {
+        const fixturesDir = path.join(__dirname, '__fixtures__')
+        const settings = {
+            urls: [url.pathToFileURL(fixturesDir).toString()],
+        }
+
+        const mentionURL = url.pathToFileURL(path.join(fixturesDir, 'io', 'index'))
+        mentionURL.hash = '#TeeReader'
+
+        const item = await expectMentionItem({ query: 'teereader' }, settings, {
+            title: 'io.TeeReader()',
+            uri: mentionURL.toString(),
+        })
+        expect(item.ai?.content).toEqual(
+            '<h3 id="TeeReader">func <span>TeeReader</span>  </h3><pre data-language="go">func TeeReader(r Reader, w Writer) Reader</pre><p>TeeReader returns a <a href="#Reader">Reader</a> that writes to w what it reads from r. All reads from r performed through it are matched with corresponding writes to w. There is no internal buffering - the write must complete before the read completes. Any error encountered while writing is reported as a read error. </p><h4 id="example_TeeReader"> <span class="text">Example</span>\n' +
+                '</h4><p>Code:</p><pre class="code" data-language="go">var r io.Reader = strings.NewReader("some io.Reader stream to be read\\n")\n' +
+                '\n' +
+                'r = io.TeeReader(r, os.Stdout)\n' +
+                '\n' +
+                '// Everything read from r will be copied to stdout.\n' +
+                'if _, err := io.ReadAll(r); err != nil {\n' +
+                '    log.Fatal(err)\n' +
+                '}\n' +
+                '\n' +
+                '</pre><p>Output:</p><pre class="output" data-language="go">some io.Reader stream to be read\n' +
+                '</pre>'
+        )
+    })
+    test.runIf(INTEGRATION)('integration test hash type', async () => {
+        const settings = {
+            urls: ['https://devdocs.io/go/'],
+        }
+
+        const item = await expectMentionItem({ query: 'teereader' }, settings, {
+            title: 'io.TeeReader()',
+            uri: 'https://devdocs.io/go/io/index#TeeReader',
+        })
+        expect(item.ai?.content).toEqual(
+            '<h3 id="TeeReader">func <span>TeeReader</span>  </h3><pre data-language="go">func TeeReader(r Reader, w Writer) Reader</pre><p>TeeReader returns a <a href="#Reader">Reader</a> that writes to w what it reads from r. All reads from r performed through it are matched with corresponding writes to w. There is no internal buffering - the write must complete before the read completes. Any error encountered while writing is reported as a read error. </p><h4 id="example_TeeReader"> <span class="text">Example</span>\n' +
+                '</h4><p>Code:</p><pre class="code" data-language="go">var r io.Reader = strings.NewReader("some io.Reader stream to be read\\n")\n' +
+                '\n' +
+                'r = io.TeeReader(r, os.Stdout)\n' +
+                '\n' +
+                '// Everything read from r will be copied to stdout.\n' +
+                'if _, err := io.ReadAll(r); err != nil {\n' +
+                '    log.Fatal(err)\n' +
+                '}\n' +
+                '\n' +
+                '</pre><p>Output:</p><pre class="output" data-language="go">some io.Reader stream to be read\n' +
+                '</pre>'
+        )
+    })
+})
+
+/**
+ * Helper which expects a certain mention back and then passes it on to items
+ */
+async function expectMentionItem(
+    params: MentionsParams,
+    settings: Settings,
+    mention: Mention
+): Promise<Item> {
+    const mentions = await devdocs.mentions!(params, settings)
+    expect(mentions).toContainEqual(mention)
+
+    const items = await devdocs.items!({ mention }, settings)
+    expect(items).toHaveLength(1)
+    const item = items[0]
+
+    expect(item.title).toEqual(mention.title)
+    expect(item.url).toEqual(mention.uri)
+
+    return item
+}

--- a/provider/devdocs/index.ts
+++ b/provider/devdocs/index.ts
@@ -1,0 +1,155 @@
+import type {
+    ItemsParams,
+    ItemsResult,
+    MentionsParams,
+    MentionsResult,
+    MetaResult,
+    Provider,
+} from '@openctx/provider'
+import Fuse from 'fuse.js'
+import { LRUCache } from 'lru-cache'
+import { parse } from 'node-html-parser'
+import { fetchDoc, fetchIndex } from './devdocs.js'
+
+/**
+ * Settings for the DevDocs OpenCtx provider.
+ */
+export type Settings = {
+    /**
+     * The list of URLs to serve.
+     *
+     * These should be top-level documentation URLs like https://devdocs.io/angular~16/ or https://devdocs.io/typescript/
+     *
+     * Additionally this supports file:// URLs for local development.
+     */
+    urls: string[]
+}
+
+/**
+ * An OpenCtx provider that fetches the content of a [DevDocs](https://devdocs.io/) entry.
+ */
+const devdocs: Provider<Settings> = {
+    meta(): MetaResult {
+        return {
+            // empty since we don't provide any annotations.
+            selector: [],
+            name: 'DevDocs',
+            features: { mentions: true },
+        }
+    },
+
+    async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {
+        const query = params.query?.toLowerCase()
+        if (!query) {
+            return []
+        }
+
+        const indexes = await Promise.all(settings.urls.map(url => getMentionIndex(url)))
+        const entries = indexes.flatMap(index => {
+            return index.fuse.search(query, { limit: 10 }).map(result => ({
+                score: result.score ?? 0,
+                item: result.item,
+                url: index.url,
+            }))
+        })
+
+        entries.sort((a, b) => a.score - b.score)
+
+        return entries.slice(0, 20).map(entry => {
+            return {
+                title: entry.item.name,
+                uri: new URL(entry.item.path, entry.url).toString(),
+            }
+        })
+    },
+
+    async items(params: ItemsParams): Promise<ItemsResult> {
+        const mention = params.mention
+        if (!mention) {
+            return []
+        }
+
+        const { content, hash } = await fetchDoc(mention.uri)
+        if (!hash) {
+            return [
+                {
+                    title: mention.title,
+                    url: mention.uri,
+                    ai: {
+                        content: content,
+                    },
+                },
+            ]
+        }
+
+        const root = parse(content)
+
+        let last = root.querySelector(hash)!
+        const nodes = [last]
+        while (true) {
+            const next = last.nextElementSibling
+            if (!next || next.rawTagName === 'h2') {
+                break
+            }
+            last = next
+            nodes.push(last)
+        }
+
+        return [
+            {
+                title: mention.title,
+                url: mention.uri,
+                ai: {
+                    content: nodes.map(node => node.toString()).join(''),
+                },
+            },
+        ]
+    },
+}
+
+// Use cache to avoid refetching index on each request.
+const cache = new LRUCache<string, MentionIndex>({
+    ttl: 1000 * 60 * 60 * 12, // 12 hours
+    ttlAutopurge: true,
+})
+
+interface MentionIndex {
+    // The normalized devdocs URL
+    url: string
+    // A fuzzy finder index. We use this to help return the best match when
+    // there are many.
+    fuse: Fuse<{ name: string; path: string }>
+}
+
+async function getMentionIndex(devdocsURL: string): Promise<MentionIndex> {
+    // ensure urls end with / to ensure we treat path as a dir when creating new relative paths.
+    if (!devdocsURL.endsWith('/')) {
+        devdocsURL = devdocsURL + '/'
+    }
+
+    if (cache.has(devdocsURL)) {
+        return cache.get(devdocsURL)!
+    }
+
+    const index = await fetchIndex(devdocsURL)
+    const entries = index.entries.map(entry => ({
+        name: entry.name,
+        path: entry.path,
+    }))
+
+    const options = {
+        includeScore: true,
+        keys: ['name'],
+    }
+    const fuse = new Fuse(entries, options)
+
+    const result = {
+        url: devdocsURL,
+        fuse,
+    }
+    cache.set(devdocsURL, result)
+
+    return result
+}
+
+export default devdocs

--- a/provider/devdocs/package.json
+++ b/provider/devdocs/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openctx/provider-devdocs",
+  "version": "0.0.1",
+  "description": "Use documentation from https://devdocs.io (OpenCtx provider)",
+  "license": "Apache-2.0",
+  "homepage": "https://openctx.org/docs/providers/devdocs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/openctx",
+    "directory": "provider/devdocs"
+  },
+  "type": "module",
+  "main": "dist/bundle.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --platform=node --outfile=dist/bundle.js index.ts",
+    "prepublishOnly": "tsc --build --clean && npm run --silent bundle",
+    "test": "vitest",
+    "update-fixtures": "node --no-warnings=ExperimentalWarning --es-module-specifier-resolution=node --loader ts-node/esm/transpile-only update-fixtures.ts"
+  },
+  "dependencies": {
+    "@openctx/provider": "workspace:*",
+    "fuse.js": "^7.0.0",
+    "lru-cache": "^10.1.0",
+    "node-html-parser": "^6.1.13"
+  }
+}

--- a/provider/devdocs/tsconfig.json
+++ b/provider/devdocs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../.config/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "lib": ["ESNext"],
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "vitest.config.ts"],
+  "references": [{ "path": "../../lib/provider" }],
+}

--- a/provider/devdocs/update-fixtures.ts
+++ b/provider/devdocs/update-fixtures.ts
@@ -1,0 +1,43 @@
+import path from 'path'
+import url from 'url'
+import fs from 'fs/promises'
+import { fetchDoc, fetchIndex } from './devdocs.js'
+
+/**
+ * USAGE pnpm update-fixtures
+ *
+ * This updates the fixtures from https://devdocs.io. We store a subset of the
+ * index.json file to avoid a large file in our repository.
+ */
+
+const __filename = url.fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+async function writeFixture(relPath: string, content: string) {
+    const p = path.join(__dirname, '__fixtures__', relPath)
+    await fs.mkdir(path.dirname(p), { recursive: true })
+    await fs.writeFile(p, content)
+}
+
+async function main() {
+    const devdocsURL = 'https://devdocs.io/go/'
+    const index = await fetchIndex(devdocsURL)
+
+    // Filter out entries that don't match what we test to reduce the size.
+    index.types = []
+    index.entries = index.entries.filter(
+        entry =>
+            entry.name.toLowerCase().includes('teereader') ||
+            entry.name.toLowerCase().includes('strconv')
+    )
+    await writeFixture('index.json', JSON.stringify(index))
+
+    const docs = ['strconv', 'io']
+    for (const slug of docs) {
+        const url = `https://devdocs.io/go/${slug}/index`
+        const { content } = await fetchDoc(url)
+        await writeFixture(path.join(slug, 'index.html'), content)
+    }
+}
+
+await main()

--- a/provider/devdocs/vitest.config.ts
+++ b/provider/devdocs/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     { "path": "client/vscode/dev" },
     { "path": "client/vscode/test/integration" },
     { "path": "client/web-playground" },
+    { "path": "provider/devdocs" },
     { "path": "provider/google-docs" },
     { "path": "provider/hello-world" },
     { "path": "provider/links" },

--- a/web/content/docs/providers/devdocs.mdx
+++ b/web/content/docs/providers/devdocs.mdx
@@ -1,0 +1,8 @@
+export const info = {
+  title: 'DevDocs',
+  group: 'providers',
+}
+
+import Readme from '../../../../provider/devdocs/README.md'
+
+<Readme />

--- a/web/pages/index/+Page.tsx
+++ b/web/pages/index/+Page.tsx
@@ -57,6 +57,7 @@ const INTEGRATIONS: IntegrationItem[] = [
     { name: 'Monaco Editor', type: 'client', slug: 'monaco-editor' },
     { name: 'CodeMirror', type: 'client', slug: 'codemirror' },
     { name: 'Storybook', type: 'provider', slug: 'storybook' },
+    { name: 'DevDocs', type: 'provider', slug: 'devdocs' },
     { name: 'Notion', type: 'provider', slug: 'notion' },
     { name: 'Prometheus', type: 'provider', slug: 'prometheus' },
     { name: 'Links', type: 'provider', slug: 'links' },


### PR DESCRIPTION
This adds an initial provider which sources documentation from https://devdocs.io/

The motivation is that often you want very specific version information for a documentation set when interacting with AI, rather than what the AI was trained on. Additionally by providing exact documentation it can improve the quality of responses.

DevDocs is a great free resource of documentation in a regular format. This makes it easier for us to consume and search.

This provider will cache the index for a documentation set for 12 hours for performance reasons (and friendliness to devdocs hosting). We use fuse.js to get some scoring on results for free. I looked into using the same scorer as devdocs, but the code is not easily reusable.

Test Plan: A unit test based on real fixture data is added. Additionally if you set `INTEGRATION=1` it will run against the real devdocs.io source.