### PR TITLE
Protocol: add mention description

### DIFF
--- a/lib/client/package.json
+++ b/lib/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/client",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "OpenCtx client library",
   "license": "Apache-2.0",
   "repository": {
@@ -11,12 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "src",
-    "!**/*.test.*",
-    "!**/testdata/**"
-  ],
+  "files": ["dist", "src", "!**/*.test.*", "!**/testdata/**"],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",

--- a/lib/protocol/package.json
+++ b/lib/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/protocol",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "OpenCtx client/provider protocol",
   "license": "Apache-2.0",
   "repository": {
@@ -11,10 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "src"
-  ],
+  "files": ["dist", "src"],
   "sideEffects": false,
   "scripts": {
     "generate": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only ../schema/dev/generateJsonSchemaTypes.ts src/openctx-protocol.schema.json \"import type { Annotation, Item } from '@openctx/schema'\" > src/openctx-protocol.schema.ts && pnpm -w exec biome check --apply-unsafe \"$PNPM_SCRIPT_SRC_DIR/src/openctx-protocol.schema.ts\"",

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -180,6 +180,10 @@
           "description": "A descriptive title.",
           "type": "string"
         },
+        "description": {
+          "description": "An item description.",
+          "type": "string"
+        },
         "uri": {
           "description": "A URI for the mention item.",
           "type": "string",

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -88,6 +88,10 @@ export interface Mention {
      */
     title: string
     /**
+     * An item description.
+     */
+    description?: string
+    /**
      * A URI for the mention item.
      */
     uri: string

--- a/lib/provider/package.json
+++ b/lib/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "OpenCtx provider library",
   "license": "Apache-2.0",
   "repository": {
@@ -11,11 +11,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "src",
-    "!**/*.test.*"
-  ],
+  "files": ["dist", "src", "!**/*.test.*"],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",


### PR DESCRIPTION
- Adds an optional `description` field to mentions, to show them when available instead of URIs.