### PR TITLE
Provider: add initial items to the Linear provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,6 +553,9 @@ importers:
       '@openctx/provider':
         specifier: workspace:*
         version: link:../../lib/provider
+      dedent:
+        specifier: ^1.5.3
+        version: 1.5.3
       fast-xml-parser:
         specifier: ^4.4.0
         version: 4.4.0
@@ -8033,6 +8036,15 @@ packages:
       mimic-response: 3.1.0
     dev: true
     optional: true
+
+  /dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+    dev: false
 
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}

--- a/provider/linear/README.md
+++ b/provider/linear/README.md
@@ -9,6 +9,15 @@ This is a context provider for [OpenCtx](https://openctx.org) that brings Linear
 1. Find "OpenCtx Linear provider config" in 1Password and add it to your user settings.
 1. Start using the provider!
 
+```json
+"openctx.providers": {
+    // ...other providers...
+    "https://openctx.org/npm/@openctx/provider-linear": {
+        "accessToken": "YOUR_ACCESS_TOKEN",
+    }
+},
+```
+
 ## Configuration outside of Sourcegraph
 
 To create Linear API credentials:
@@ -24,7 +33,7 @@ Then use the following OpenCtx provider configuration:
 "openctx.providers": {
     // ...other providers...
     "https://openctx.org/npm/@openctx/provider-linear": {
-        "linearUserCredentialsPath": "path/to/access_token_file_printed.json",
+        "userCredentialsPath": "path/to/access_token_file_printed.json",
     }
 },
 ```

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -7,19 +7,21 @@ import type {
     MetaResult,
     Provider,
 } from '@openctx/provider'
+import dedent from 'dedent'
 import { XMLBuilder } from 'fast-xml-parser'
 
 import type { UserCredentials } from './auth.js'
 
 /** Settings for the Linear OpenCtx provider. */
 export type Settings = {
-    linearUserCredentialsPath?: string
-    linearClientCredentials?: { accessToken?: string }
+    userCredentialsPath?: string
+    accessToken?: string
 }
 
 const xmlBuilder = new XMLBuilder({ format: true })
 
 interface Issue {
+    identifier: string
     title: string
     url: string
     description: string
@@ -32,34 +34,36 @@ interface Comment {
     body: string
 }
 
+const NUMBER_OF_ISSUES_TO_FETCH = 10
+
 const linearIssues: Provider<Settings> = {
     meta(): MetaResult {
         return { name: 'Linear Issues', features: { mentions: true } }
     },
 
     async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {
-        if (!params.query || params.query.length < 3) {
-            return []
+        let issues: Issue[] = []
+
+        if (params.query) {
+            const variables = { query: params.query, first: NUMBER_OF_ISSUES_TO_FETCH }
+            const response = await linearApiRequest(issueSearchQuery, variables, settingsInput)
+            issues = response.data.issueSearch.nodes as Issue[]
+        } else {
+            const variables = { first: NUMBER_OF_ISSUES_TO_FETCH / 2 }
+            const response = await linearApiRequest(viewerIssuesQuery, variables, settingsInput)
+
+            const createdIssues = response.data.viewer.createdIssues.nodes as Issue[]
+            const assignedIssues = response.data.viewer.createdIssues.nodes as Issue[]
+            issues = dedupeWith([...assignedIssues, ...createdIssues], 'url')
         }
 
-        const query = `
-            query IssueSearch($query: String!, $first: Int!) {
-                issueSearch(query: $query, first: $first, orderBy: updatedAt) {
-                    nodes {
-                        title
-                        url
-                    }
-                }
-            }
-        `
-        const variables = { query: params.query, first: 10 }
-        const response = await linearApiRequest(query, variables, settingsInput)
-        const issues = response.data.issueSearch.nodes as Issue[]
-
-        return (issues ?? []).map(issue => ({
-            title: issue.title,
+        const mentions = (issues ?? []).map(issue => ({
+            title: `${issue.identifier} ${issue.title}`,
             uri: issue.url,
+            description: issue.description,
         }))
+
+        return mentions
     },
 
     async items(params: ItemsParams, settingsInput: Settings): Promise<ItemsResult> {
@@ -72,30 +76,23 @@ const linearIssues: Provider<Settings> = {
             return []
         }
 
-        const query = `
-            query Issue($id: String!) {
-                issue(id: $id) {
-                    title
-                    description
-                    comments {
-                        nodes {
-                            body
-                        }
-                    }
-                }
-            }
-        `
         const variables = { id: issueId }
-        const data = await linearApiRequest(query, variables, settingsInput)
+        const data = await linearApiRequest(issueWithCommentsQuery, variables, settingsInput)
         const issue = data.data.issue as Issue
         const comments = issue.comments?.nodes as Comment[]
 
-        const content = xmlBuilder.build({
-            linear_issue: {
-                description: issue.description || '',
-                comments: comments.map(comment => comment.body).join('\n'),
-            },
+        const issueInfo = xmlBuilder.build({
+            title: issue.title,
+            description: issue.description || '',
+            comments: comments.map(comment => comment.body).join('\n'),
+            url: issue.url,
         })
+        const content = dedent`
+            Here is the Linear issue. Use it to check if it helps.
+            Ignore it if it is not relevant.
+
+            ${issueInfo}
+        `
 
         return [
             {
@@ -112,23 +109,23 @@ const linearIssues: Provider<Settings> = {
 export default linearIssues
 
 function getAccessToken(settings: Settings): string {
-    if (settings.linearClientCredentials?.accessToken) {
-        return settings.linearClientCredentials.accessToken
+    if (settings?.accessToken) {
+        return settings.accessToken
     }
 
-    if (settings.linearUserCredentialsPath) {
-        const userCredentialsString = readFileSync(settings.linearUserCredentialsPath, 'utf-8')
+    if (settings.userCredentialsPath) {
+        const userCredentialsString = readFileSync(settings.userCredentialsPath, 'utf-8')
         const userCredentials = JSON.parse(userCredentialsString) as Partial<UserCredentials>
 
         if (!userCredentials.access_token) {
-            throw new Error(`access_token not found in ${settings.linearUserCredentialsPath}`)
+            throw new Error(`access_token not found in ${settings.userCredentialsPath}`)
         }
 
         return userCredentials.access_token
     }
 
     throw new Error(
-        'must provide a Linear user credentials path in the `linearUserCredentialsPath` settings field or an accessToken in the linearClientOptions'
+        'must provide a Linear user credentials path in the `userCredentialsPath` settings field or an accessToken in the linearClientOptions'
     )
 }
 
@@ -168,3 +165,71 @@ function parseIssueIDFromURL(urlStr: string): string | undefined {
     const match = url.pathname.match(/\/issue\/([a-zA-Z0-9_-]+)/)
     return match ? match[1] : undefined
 }
+
+const dedupeWith = <T>(items: T[], key: keyof T | ((item: T) => string)): T[] => {
+    const seen = new Set()
+    const isKeyFunction = typeof key === 'function'
+
+    return items.reduce((result, item) => {
+        const itemKey = isKeyFunction ? key(item) : item[key]
+
+        if (!seen.has(itemKey)) {
+            seen.add(itemKey)
+            result.push(item)
+        }
+
+        return result
+    }, [] as T[])
+}
+
+const issueFragment = `
+  fragment IssueFragment on Issue {
+      identifier
+      title
+      url
+      description
+  }
+`
+const viewerIssuesQuery = `
+  query ViewerIssues($first: Int!) {
+    viewer {
+      createdIssues(first: $first, orderBy: updatedAt) {
+        nodes {
+          ...IssueFragment
+        }
+      }
+      assignedIssues(first: $first, orderBy: updatedAt) {
+        nodes {
+          ...IssueFragment
+        }
+      }
+    }
+  }
+
+  ${issueFragment}
+`
+const issueSearchQuery = `
+    query IssueSearch($query: String!, $first: Int!) {
+        issueSearch(query: $query, first: $first, orderBy: updatedAt) {
+            nodes {
+              ...IssueFragment
+            }
+        }
+    }
+
+    ${issueFragment}
+`
+const issueWithCommentsQuery = `
+  query IssueWithComment($id: String!) {
+    issue(id: $id) {
+      identifier
+      title
+      description
+      comments {
+        nodes {
+          body
+        }
+      }
+    }
+  }
+`

--- a/provider/linear/package.json
+++ b/provider/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-linear",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Linear context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {
@@ -11,10 +11,7 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist/bundle.js",
-    "dist/index.d.ts"
-  ],
+  "files": ["dist/bundle.js", "dist/index.d.ts"],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",

--- a/provider/linear/package.json
+++ b/provider/linear/package.json
@@ -11,7 +11,10 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist/bundle.js", "dist/index.d.ts"],
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",
@@ -23,6 +26,7 @@
   },
   "dependencies": {
     "@openctx/provider": "workspace:*",
+    "dedent": "^1.5.3",
     "fast-xml-parser": "^4.4.0",
     "open": "^10.0.4",
     "server-destroy": "^1.0.1"


### PR DESCRIPTION
- Show created/assigned items for the current user when the query is empty
- Simplify the configuration schema
- Update docs
- Uses `mention.description` instead of `mention.uri`.

## Test plan

Test manually