### PR TITLE
Add mention selectors to OpenCtx provider protocol

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -12,7 +12,7 @@ $ npm install -g @openctx/cli@latest
 $ export OPENCTX_CONFIG='{"enable":true,"debug":true,"providers":{"https://openctx.org/npm/@openctx/provider-web": true}}'
 
 $ openctx meta
-[{"selector":[],"name":"URLs",...}]
+[{"name":"URLs", "featues": {"annotations": "selectors": []}, ...}]
 
 $ openctx mentions https://example.com
 #1 Example Domain — https://example.com

--- a/bin/README.md
+++ b/bin/README.md
@@ -12,7 +12,7 @@ $ npm install -g @openctx/cli@latest
 $ export OPENCTX_CONFIG='{"enable":true,"debug":true,"providers":{"https://openctx.org/npm/@openctx/provider-web": true}}'
 
 $ openctx meta
-[{"name":"URLs", "featues": {"annotations": "selectors": []}, ...}]
+[{"name":"URLs", "annotations": {"selectors": []}, ...}]
 
 $ openctx mentions https://example.com
 #1 Example Domain — https://example.com

--- a/lib/client/src/client/testdata/simple.js
+++ b/lib/client/src/client/testdata/simple.js
@@ -1,6 +1,6 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ features: { annotations: { implements: true } } }),
+    meta: () => ({ annotations: {} }),
     items: () => [
         {
             title: 'A',

--- a/lib/client/src/client/testdata/simple.js
+++ b/lib/client/src/client/testdata/simple.js
@@ -1,6 +1,6 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({}),
+    meta: () => ({ features: { annotations: { implements: true } } }),
     items: () => [
         {
             title: 'A',

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -91,7 +91,7 @@ export function createProviderClient(
                 logger?.('checking provider meta')
                 const meta = await transport.meta({}, settings)
                 logger?.(`received meta = ${JSON.stringify(meta)}`)
-                match = matchSelectors(meta.selector)
+                match = matchSelectors(meta.features?.annotations?.selectors)
             } catch (error) {
                 logger?.(`failed to get provider meta: ${error}`)
                 return Promise.reject(error)

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -91,7 +91,11 @@ export function createProviderClient(
                 logger?.('checking provider meta')
                 const meta = await transport.meta({}, settings)
                 logger?.(`received meta = ${JSON.stringify(meta)}`)
-                match = matchSelectors(meta.features?.annotations?.selectors)
+                match = () => false
+
+                if (meta?.features?.annotations?.implements) {
+                    match = matchSelectors(meta.features?.annotations?.selectors)
+                }
             } catch (error) {
                 logger?.(`failed to get provider meta: ${error}`)
                 return Promise.reject(error)

--- a/lib/client/src/providerClient/createProviderClient.ts
+++ b/lib/client/src/providerClient/createProviderClient.ts
@@ -93,8 +93,8 @@ export function createProviderClient(
                 logger?.(`received meta = ${JSON.stringify(meta)}`)
                 match = () => false
 
-                if (meta?.features?.annotations?.implements) {
-                    match = matchSelectors(meta.features?.annotations?.selectors)
+                if (meta?.annotations) {
+                    match = matchSelectors(meta.annotations?.selectors)
                 }
             } catch (error) {
                 logger?.(`failed to get provider meta: ${error}`)

--- a/lib/client/src/providerClient/selector.ts
+++ b/lib/client/src/providerClient/selector.ts
@@ -1,4 +1,4 @@
-import type { AnnotationsParams, Selector } from '@openctx/protocol'
+import type { AnnotationSelector, AnnotationsParams } from '@openctx/protocol'
 //
 // Import from a subpackage because the main module calls `os.platform()`, which doesn't work on
 // non-Node engines.
@@ -9,7 +9,7 @@ import match from 'picomatch/lib/picomatch.js'
  * docs for the selector specification.
  */
 export function matchSelectors(
-    selectors: Selector[] | undefined
+    selectors: AnnotationSelector[] | undefined
 ): (params: AnnotationsParams) => boolean {
     if (selectors === undefined) {
         return ALWAYS_TRUE
@@ -23,7 +23,7 @@ export function matchSelectors(
 
 const ALWAYS_TRUE = (): boolean => true
 
-function matchSelector(selector: Selector): (filePath: string, content: string) => boolean {
+function matchSelector(selector: AnnotationSelector): (filePath: string, content: string) => boolean {
     const matchPath =
         selector.path !== undefined && selector.path !== null
             ? match(trimLeadingSlash(selector.path))

--- a/lib/client/src/providerClient/testdata/methodsThrow.js
+++ b/lib/client/src/providerClient/testdata/methodsThrow.js
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
     meta() {
-        return {}
+        return { features: { annotations: { implements: true } } }
     },
     items() {
         throw new Error('itemsThrow')

--- a/lib/client/src/providerClient/testdata/methodsThrow.js
+++ b/lib/client/src/providerClient/testdata/methodsThrow.js
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
     meta() {
-        return { features: { annotations: { implements: true } } }
+        return { annotations: {} }
     },
     items() {
         throw new Error('itemsThrow')

--- a/lib/client/src/providerClient/testdata/provider.js
+++ b/lib/client/src/providerClient/testdata/provider.js
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
     items: (_params, settings) => [

--- a/lib/client/src/providerClient/testdata/provider.js
+++ b/lib/client/src/providerClient/testdata/provider.js
@@ -1,6 +1,9 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
     items: (_params, settings) => [
         {
             title: settings.myTitle,

--- a/lib/client/src/providerClient/testdata/transportReuse.js
+++ b/lib/client/src/providerClient/testdata/transportReuse.js
@@ -4,7 +4,7 @@ global.__test__transportReuseInfo.moduleLoads++
 export default {
     meta() {
         global.__test__transportReuseInfo.metaCalls++
-        return { features: { annotations: { implements: true } } }
+        return { annotations: {} }
     },
     items() {
         global.__test__transportReuseInfo.itemsCalls++

--- a/lib/client/src/providerClient/testdata/transportReuse.js
+++ b/lib/client/src/providerClient/testdata/transportReuse.js
@@ -4,7 +4,7 @@ global.__test__transportReuseInfo.moduleLoads++
 export default {
     meta() {
         global.__test__transportReuseInfo.metaCalls++
-        return {}
+        return { features: { annotations: { implements: true } } }
     },
     items() {
         global.__test__transportReuseInfo.itemsCalls++

--- a/lib/client/src/providerClient/transport/createTransport.test.ts
+++ b/lib/client/src/providerClient/transport/createTransport.test.ts
@@ -6,7 +6,7 @@ import { type ProviderTransport, createTransport } from './createTransport.js'
 
 async function expectProviderTransport(provider: ProviderTransport) {
     expect(await provider.meta({}, {})).toEqual<MetaResult>({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     })
 }
@@ -58,11 +58,8 @@ describe('createTransport', () => {
             fetchMocker.mockOnce(
                 JSON.stringify({
                     result: {
-                        features: {
-                            annotations: {
-                                implements: true,
-                                selectors: [{ path: 'foo' }],
-                            },
+                        annotations: {
+                            selectors: [{ path: 'foo' }],
                         },
                         name: 'foo',
                     } satisfies MetaResult,

--- a/lib/client/src/providerClient/transport/createTransport.test.ts
+++ b/lib/client/src/providerClient/transport/createTransport.test.ts
@@ -6,7 +6,7 @@ import { type ProviderTransport, createTransport } from './createTransport.js'
 
 async function expectProviderTransport(provider: ProviderTransport) {
     expect(await provider.meta({}, {})).toEqual<MetaResult>({
-        selector: [{ path: 'foo' }],
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
         name: 'foo',
     })
 }
@@ -58,7 +58,12 @@ describe('createTransport', () => {
             fetchMocker.mockOnce(
                 JSON.stringify({
                     result: {
-                        selector: [{ path: 'foo' }],
+                        features: {
+                            annotations: {
+                                implements: true,
+                                selectors: [{ path: 'foo' }],
+                            },
+                        },
                         name: 'foo',
                     } satisfies MetaResult,
                 } satisfies ResponseMessage)

--- a/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
+++ b/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
@@ -1,4 +1,7 @@
 /** @type {import('@openctx/provider').OpenCtxProvider} */
 module.exports = {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
 }

--- a/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
+++ b/lib/client/src/providerClient/transport/testdata/commonjsExtProvider.cjs
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').OpenCtxProvider} */
 module.exports = {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
 }

--- a/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 module.exports = {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
 }

--- a/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/commonjsProvider.js
@@ -1,4 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 module.exports = {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
 }

--- a/lib/client/src/providerClient/transport/testdata/emoji.js
+++ b/lib/client/src/providerClient/transport/testdata/emoji.js
@@ -1,5 +1,8 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
 }
 // ✨

--- a/lib/client/src/providerClient/transport/testdata/emoji.js
+++ b/lib/client/src/providerClient/transport/testdata/emoji.js
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
+++ b/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
+++ b/lib/client/src/providerClient/transport/testdata/esmExtProvider.mjs
@@ -1,4 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.js
@@ -1,7 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.js
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.js
@@ -1,4 +1,7 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
 }

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.ts
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.ts
@@ -1,7 +1,10 @@
 import type { Provider } from '@openctx/provider'
 
 const provider: Provider = {
-    meta: () => ({ selector: [{ path: 'foo' }], name: 'foo' }),
+    meta: () => ({
+        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        name: 'foo',
+    }),
     annotations: () => [],
 }
 

--- a/lib/client/src/providerClient/transport/testdata/esmProvider.ts
+++ b/lib/client/src/providerClient/transport/testdata/esmProvider.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@openctx/provider'
 
 const provider: Provider = {
     meta: () => ({
-        features: { annotations: { implements: true, selectors: [{ path: 'foo' }] } },
+        annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     }),
     annotations: () => [],

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -147,48 +147,33 @@
           "description": "The name of the provider.",
           "type": "string"
         },
-        "features": {
-          "description": "The features supported by the provider.",
+        "mentions": {
+          "description": "Configuration for the mentions feature.",
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "mentions": {
-              "description": "Configuration for the mentions feature.",
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "implements": {
-                  "description": "Whether the provider implements the mentions feature",
-                  "type": "boolean"
-                },
-                "selectors": {
-                  "description": "A list of patterns matching the mention text for which the provider can return mentions",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/MentionSelector"
-                  },
-                  "tsType": "MentionSelector[]"
-                }
-              }
-            },
-            "annotations": {
-              "description": "Configuration for the annotations feature.",
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "implements": {
-                  "description": "Whether the provider implements the mentions feature",
-                  "type": "boolean"
-                },
-                "selectors": {
-                  "description": "A list of patterns matching the mention text for which the provider can return mentions",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/AnnotationSelector"
-                  },
-                  "tsType": "AnnotationSelector[]"
-                }
-              }
+            "selectors": {
+              "description": "The list of regex patterns for triggering mentions for the provider when users directly types a matching text, for example a url, allowing the user to bypass choosing the provider manually.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MentionSelector"
+              },
+              "tsType": "MentionSelector[]"
+            }
+          }
+        },
+        "annotations": {
+          "description": "Configuration for the annotations feature.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "selectors": {
+              "description": "A list of patterns matching the mention text for which the provider can return mentions",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AnnotationSelector"
+              },
+              "tsType": "AnnotationSelector[]"
             }
           }
         }

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -27,9 +27,6 @@
       "$ref": "#/definitions/Mention"
     },
     {
-      "$ref": "#/definitions/MentionKind"
-    },
-    {
       "$ref": "#/definitions/MentionSelector"
     },
     {
@@ -126,26 +123,6 @@
         }
       }
     },
-    "MentionKind": {
-      "type": "object",
-      "description": "A mention kind supported by the provider.",
-      "additionalProperties": false,
-      "required": ["id", "title"],
-      "properties": {
-        "id": {
-          "description": "The unique identifier for the mention kind.",
-          "type": "string"
-        },
-        "title": {
-          "description": "The title of the mention kind.",
-          "type": "string"
-        },
-        "description": {
-          "description": "The description of the mention kind.",
-          "type": "string"
-        }
-      }
-    },
     "AnnotationSelector": {
       "description": "Defines a scope in which a provider is called.\n\nTo satisfy a selector, all of the selector's conditions must be met. For example, if both `path` and `content` are specified, the resource must satisfy both conditions.",
       "type": "object",
@@ -191,13 +168,6 @@
                     "$ref": "#/definitions/MentionSelector"
                   },
                   "tsType": "MentionSelector[]"
-                },
-                "kinds": {
-                  "description": "A list of kinds of  mentions the provider supports.",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/MentionKind"
-                  }
                 }
               }
             },
@@ -280,10 +250,6 @@
       "properties": {
         "query": {
           "description": "A search query that is interpreted by providers to filter the items in the result set.",
-          "type": "string"
-        },
-        "kind": {
-          "description": "The id of the mention kind to return.",
           "type": "string"
         }
       }

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -27,6 +27,15 @@
       "$ref": "#/definitions/Mention"
     },
     {
+      "$ref": "#/definitions/MentionKind"
+    },
+    {
+      "$ref": "#/definitions/MentionSelector"
+    },
+    {
+      "$ref": "#/definitions/AnnotationSelector"
+    },
+    {
       "$ref": "#/definitions/MentionsParams"
     },
     {
@@ -105,31 +114,58 @@
       "properties": {},
       "tsType": "Record<string, never>"
     },
+    "MentionSelector": {
+      "description": "List of regex patterns matching the mention text for which the provider can return mentions.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "description": "The regex pattern matching the mention text for which the provider can return mentions",
+          "type": "string"
+        }
+      }
+    },
+    "MentionKind": {
+      "type": "object",
+      "description": "A mention kind supported by the provider.",
+      "additionalProperties": false,
+      "required": ["id", "title"],
+      "properties": {
+        "id": {
+          "description": "The unique identifier for the mention kind.",
+          "type": "string"
+        },
+        "title": {
+          "description": "The title of the mention kind.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The description of the mention kind.",
+          "type": "string"
+        }
+      }
+    },
+    "AnnotationSelector": {
+      "description": "Defines a scope in which a provider is called.\n\nTo satisfy a selector, all of the selector's conditions must be met. For example, if both `path` and `content` are specified, the resource must satisfy both conditions.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "A glob that must match the resource's hostname and path.\n\nUse `**/` before the glob to match in any parent directory. Use `/**` after the glob to match any resources under a directory. Leading slashes are stripped from the path before being matched against the glob.",
+          "type": "string"
+        },
+        "contentContains": {
+          "description": "A literal string that must be present in the resource's content.",
+          "type": "string"
+        }
+      }
+    },
     "MetaResult": {
       "type": "object",
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
-        "selector": {
-          "description": "Selects the scope in which this provider should be called.\n\nAt least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.",
-          "type": "array",
-          "items": {
-            "title": "Selector",
-            "description": "Defines a scope in which a provider is called.\n\nTo satisfy a selector, all of the selector's conditions must be met. For example, if both `path` and `content` are specified, the resource must satisfy both conditions.",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "path": {
-                "description": "A glob that must match the resource's hostname and path.\n\nUse `**/` before the glob to match in any parent directory. Use `/**` after the glob to match any resources under a directory. Leading slashes are stripped from the path before being matched against the glob.",
-                "type": "string"
-              },
-              "contentContains": {
-                "description": "A literal string that must be present in the resource's content.",
-                "type": "string"
-              }
-            }
-          }
-        },
         "name": {
           "description": "The name of the provider.",
           "type": "string"
@@ -140,8 +176,49 @@
           "additionalProperties": false,
           "properties": {
             "mentions": {
-              "description": "Whether the provider support mentions.",
-              "type": "boolean"
+              "description": "Configuration for the mentions feature.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "implements": {
+                  "description": "Whether the provider implements the mentions feature",
+                  "type": "boolean"
+                },
+                "selectors": {
+                  "description": "A list of patterns matching the mention text for which the provider can return mentions",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/MentionSelector"
+                  },
+                  "tsType": "MentionSelector[]"
+                },
+                "kinds": {
+                  "description": "A list of kinds of  mentions the provider supports.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/MentionKind"
+                  }
+                }
+              }
+            },
+            "annotations": {
+              "description": "Configuration for the annotations feature.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "implements": {
+                  "description": "Whether the provider implements the mentions feature",
+                  "type": "boolean"
+                },
+                "selectors": {
+                  "description": "A list of patterns matching the mention text for which the provider can return mentions",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AnnotationSelector"
+                  },
+                  "tsType": "AnnotationSelector[]"
+                }
+              }
             }
           }
         }
@@ -203,6 +280,10 @@
       "properties": {
         "query": {
           "description": "A search query that is interpreted by providers to filter the items in the result set.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The id of the mention kind to return.",
           "type": "string"
         }
       }

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -10,7 +10,6 @@ export type Protocol =
     | MetaParams
     | MetaResult
     | Mention
-    | MentionKind
     | MentionSelector
     | AnnotationSelector
     | MentionsParams
@@ -65,10 +64,6 @@ export interface MetaResult {
              * A list of patterns matching the mention text for which the provider can return mentions
              */
             selectors?: MentionSelector[]
-            /**
-             * A list of kinds of  mentions the provider supports.
-             */
-            kinds?: MentionKind[]
         }
         /**
          * Configuration for the annotations feature.
@@ -84,23 +79,6 @@ export interface MetaResult {
             selectors?: AnnotationSelector[]
         }
     }
-}
-/**
- * A mention kind supported by the provider.
- */
-export interface MentionKind {
-    /**
-     * The unique identifier for the mention kind.
-     */
-    id: string
-    /**
-     * The title of the mention kind.
-     */
-    title: string
-    /**
-     * The description of the mention kind.
-     */
-    description?: string
 }
 /**
  * A mention contains presentation information relevant to a resource.
@@ -153,10 +131,6 @@ export interface MentionsParams {
      * A search query that is interpreted by providers to filter the items in the result set.
      */
     query?: string
-    /**
-     * The id of the mention kind to return.
-     */
-    kind?: string
 }
 export interface ItemsParams {
     /**

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -10,6 +10,9 @@ export type Protocol =
     | MetaParams
     | MetaResult
     | Mention
+    | MentionKind
+    | MentionSelector
+    | AnnotationSelector
     | MentionsParams
     | MentionsResult
     | ItemsParams
@@ -43,12 +46,6 @@ export interface ResponseError {
 }
 export interface MetaResult {
     /**
-     * Selects the scope in which this provider should be called.
-     *
-     * At least 1 must be satisfied for the provider to be called. If empty, the provider is never called. If undefined, the provider is called on all resources.
-     */
-    selector?: Selector[]
-    /**
      * The name of the provider.
      */
     name: string
@@ -57,27 +54,53 @@ export interface MetaResult {
      */
     features?: {
         /**
-         * Whether the provider support mentions.
+         * Configuration for the mentions feature.
          */
-        mentions?: boolean
+        mentions?: {
+            /**
+             * Whether the provider implements the mentions feature
+             */
+            implements?: boolean
+            /**
+             * A list of patterns matching the mention text for which the provider can return mentions
+             */
+            selectors?: MentionSelector[]
+            /**
+             * A list of kinds of  mentions the provider supports.
+             */
+            kinds?: MentionKind[]
+        }
+        /**
+         * Configuration for the annotations feature.
+         */
+        annotations?: {
+            /**
+             * Whether the provider implements the mentions feature
+             */
+            implements?: boolean
+            /**
+             * A list of patterns matching the mention text for which the provider can return mentions
+             */
+            selectors?: AnnotationSelector[]
+        }
     }
 }
 /**
- * Defines a scope in which a provider is called.
- *
- * To satisfy a selector, all of the selector's conditions must be met. For example, if both `path` and `content` are specified, the resource must satisfy both conditions.
+ * A mention kind supported by the provider.
  */
-export interface Selector {
+export interface MentionKind {
     /**
-     * A glob that must match the resource's hostname and path.
-     *
-     * Use `** /` before the glob to match in any parent directory. Use `/**` after the glob to match any resources under a directory. Leading slashes are stripped from the path before being matched against the glob.
+     * The unique identifier for the mention kind.
      */
-    path?: string
+    id: string
     /**
-     * A literal string that must be present in the resource's content.
+     * The title of the mention kind.
      */
-    contentContains?: string
+    title: string
+    /**
+     * The description of the mention kind.
+     */
+    description?: string
 }
 /**
  * A mention contains presentation information relevant to a resource.
@@ -99,11 +122,41 @@ export interface Mention {
         [k: string]: unknown | undefined
     }
 }
+/**
+ * List of regex patterns matching the mention text for which the provider can return mentions.
+ */
+export interface MentionSelector {
+    /**
+     * The regex pattern matching the mention text for which the provider can return mentions
+     */
+    pattern: string
+}
+/**
+ * Defines a scope in which a provider is called.
+ *
+ * To satisfy a selector, all of the selector's conditions must be met. For example, if both `path` and `content` are specified, the resource must satisfy both conditions.
+ */
+export interface AnnotationSelector {
+    /**
+     * A glob that must match the resource's hostname and path.
+     *
+     * Use `** /` before the glob to match in any parent directory. Use `/**` after the glob to match any resources under a directory. Leading slashes are stripped from the path before being matched against the glob.
+     */
+    path?: string
+    /**
+     * A literal string that must be present in the resource's content.
+     */
+    contentContains?: string
+}
 export interface MentionsParams {
     /**
      * A search query that is interpreted by providers to filter the items in the result set.
      */
     query?: string
+    /**
+     * The id of the mention kind to return.
+     */
+    kind?: string
 }
 export interface ItemsParams {
     /**

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -49,35 +49,22 @@ export interface MetaResult {
      */
     name: string
     /**
-     * The features supported by the provider.
+     * Configuration for the mentions feature.
      */
-    features?: {
+    mentions?: {
         /**
-         * Configuration for the mentions feature.
+         * The list of regex patterns for triggering mentions for the provider when users directly types a matching text, for example a url, allowing the user to bypass choosing the provider manually.
          */
-        mentions?: {
-            /**
-             * Whether the provider implements the mentions feature
-             */
-            implements?: boolean
-            /**
-             * A list of patterns matching the mention text for which the provider can return mentions
-             */
-            selectors?: MentionSelector[]
-        }
+        selectors?: MentionSelector[]
+    }
+    /**
+     * Configuration for the annotations feature.
+     */
+    annotations?: {
         /**
-         * Configuration for the annotations feature.
+         * A list of patterns matching the mention text for which the provider can return mentions
          */
-        annotations?: {
-            /**
-             * Whether the provider implements the mentions feature
-             */
-            implements?: boolean
-            /**
-             * A list of patterns matching the mention text for which the provider can return mentions
-             */
-            selectors?: AnnotationSelector[]
-        }
+        selectors?: AnnotationSelector[]
     }
 }
 /**

--- a/provider/devdocs/index.ts
+++ b/provider/devdocs/index.ts
@@ -31,10 +31,8 @@ export type Settings = {
 const devdocs: Provider<Settings> = {
     meta(): MetaResult {
         return {
-            // empty since we don't provide any annotations.
-            selector: [],
             name: 'DevDocs',
-            features: { mentions: true },
+            features: { mentions: { implements: true } },
         }
     },
 

--- a/provider/devdocs/index.ts
+++ b/provider/devdocs/index.ts
@@ -32,7 +32,7 @@ const devdocs: Provider<Settings> = {
     meta(): MetaResult {
         return {
             name: 'DevDocs',
-            features: { mentions: { implements: true } },
+            mentions: {},
         }
     },
 

--- a/provider/github/index.ts
+++ b/provider/github/index.ts
@@ -19,7 +19,7 @@ const xmlBuilder = new XMLBuilder({
 
 const github: Provider<GithubProviderSettings> = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
-        return { name: 'Github PRs & Issues', features: { mentions: true } }
+        return { name: 'Github PRs & Issues', features: { mentions: { implements: true } } }
     },
 
     async mentions({ query }, settings) {

--- a/provider/github/index.ts
+++ b/provider/github/index.ts
@@ -19,7 +19,7 @@ const xmlBuilder = new XMLBuilder({
 
 const github: Provider<GithubProviderSettings> = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
-        return { name: 'Github PRs & Issues', features: { mentions: { implements: true } } }
+        return { name: 'Github PRs & Issues', mentions: {} }
     },
 
     async mentions({ query }, settings) {

--- a/provider/google-docs/index.test.ts
+++ b/provider/google-docs/index.test.ts
@@ -5,7 +5,10 @@ describe('googleDocs', () => {
     const SETTINGS: Settings = {}
 
     test('meta', async () => {
-        expect(await googleDocs.meta({}, SETTINGS)).toEqual({ name: 'Google Docs' })
+        expect(await googleDocs.meta({}, SETTINGS)).toEqual({
+            name: 'Google Docs',
+            features: { mentions: { implements: true } },
+        })
     })
 })
 

--- a/provider/google-docs/index.test.ts
+++ b/provider/google-docs/index.test.ts
@@ -7,7 +7,7 @@ describe('googleDocs', () => {
     test('meta', async () => {
         expect(await googleDocs.meta({}, SETTINGS)).toEqual({
             name: 'Google Docs',
-            features: { mentions: { implements: true } },
+            mentions: {},
         })
     })
 })

--- a/provider/google-docs/index.ts
+++ b/provider/google-docs/index.ts
@@ -30,7 +30,7 @@ export type Settings = {
  */
 const googleDocs: Provider<Settings> = {
     meta(): MetaResult {
-        return { name: 'Google Docs' }
+        return { name: 'Google Docs', features: { mentions: { implements: true } } }
     },
 
     async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {

--- a/provider/google-docs/index.ts
+++ b/provider/google-docs/index.ts
@@ -30,7 +30,7 @@ export type Settings = {
  */
 const googleDocs: Provider<Settings> = {
     meta(): MetaResult {
-        return { name: 'Google Docs', features: { mentions: { implements: true } } }
+        return { name: 'Google Docs', mentions: {} }
     },
 
     async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {

--- a/provider/hello-world/index.test.ts
+++ b/provider/hello-world/index.test.ts
@@ -6,6 +6,7 @@ describe('helloWorld', () => {
     test('meta', () =>
         expect(helloWorld.meta({}, {})).toStrictEqual<MetaResult>({
             name: '✨ Hello World!',
+            features: { annotations: { implements: true } },
         }))
 
     test('annotations', () =>

--- a/provider/hello-world/index.test.ts
+++ b/provider/hello-world/index.test.ts
@@ -6,7 +6,7 @@ describe('helloWorld', () => {
     test('meta', () =>
         expect(helloWorld.meta({}, {})).toStrictEqual<MetaResult>({
             name: '✨ Hello World!',
-            features: { annotations: { implements: true } },
+            annotations: {},
         }))
 
     test('annotations', () =>

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -16,7 +16,7 @@ import type {
  */
 const helloWorld: Provider = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
-        return { name: '✨ Hello World!' }
+        return { name: '✨ Hello World!', features: { annotations: { implements: true } } }
     },
 
     items(params: ItemsParams, settings: ProviderSettings): ItemsResult {

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -16,7 +16,7 @@ import type {
  */
 const helloWorld: Provider = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
-        return { name: '✨ Hello World!', features: { annotations: { implements: true } } }
+        return { name: '✨ Hello World!', annotations: {} }
     },
 
     items(params: ItemsParams, settings: ProviderSettings): ItemsResult {

--- a/provider/jira/index.ts
+++ b/provider/jira/index.ts
@@ -35,7 +35,7 @@ const issueToItemContent = (issue: JiraIssue): string => {
 
 const jiraProvider: Provider = {
     meta(params: MetaParams, settings: Settings): MetaResult {
-        return { name: 'Jira', features: { mentions: true } }
+        return { name: 'Jira', features: { mentions: { implements: true } } }
     },
 
     async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {

--- a/provider/jira/index.ts
+++ b/provider/jira/index.ts
@@ -35,7 +35,7 @@ const issueToItemContent = (issue: JiraIssue): string => {
 
 const jiraProvider: Provider = {
     meta(params: MetaParams, settings: Settings): MetaResult {
-        return { name: 'Jira', features: { mentions: { implements: true } } }
+        return { name: 'Jira', mentions: {} }
     },
 
     async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -38,7 +38,7 @@ const NUMBER_OF_ISSUES_TO_FETCH = 10
 
 const linearIssues: Provider<Settings> = {
     meta(): MetaResult {
-        return { name: 'Linear Issues', features: { mentions: { implements: true } } }
+        return { name: 'Linear Issues', mentions: {} }
     },
 
     async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {

--- a/provider/linear/index.ts
+++ b/provider/linear/index.ts
@@ -38,7 +38,7 @@ const NUMBER_OF_ISSUES_TO_FETCH = 10
 
 const linearIssues: Provider<Settings> = {
     meta(): MetaResult {
-        return { name: 'Linear Issues', features: { mentions: true } }
+        return { name: 'Linear Issues', features: { mentions: { implements: true } } }
     },
 
     async mentions(params: MentionsParams, settingsInput: Settings): Promise<MentionsResult> {

--- a/provider/links/index.test.ts
+++ b/provider/links/index.test.ts
@@ -24,11 +24,8 @@ describe('links', () => {
 
     test('meta', async () => {
         expect(await links.meta({}, SETTINGS)).toStrictEqual<MetaResult>({
-            features: {
-                annotations: {
-                    implements: true,
-                    selectors: [{ path: '**/*.ts' }, { path: '**/*.go' }],
-                },
+            annotations: {
+                selectors: [{ path: '**/*.ts' }, { path: '**/*.go' }],
             },
             name: 'Links',
         })

--- a/provider/links/index.test.ts
+++ b/provider/links/index.test.ts
@@ -24,7 +24,12 @@ describe('links', () => {
 
     test('meta', async () => {
         expect(await links.meta({}, SETTINGS)).toStrictEqual<MetaResult>({
-            selector: [{ path: '**/*.ts' }, { path: '**/*.go' }],
+            features: {
+                annotations: {
+                    implements: true,
+                    selectors: [{ path: '**/*.ts' }, { path: '**/*.go' }],
+                },
+            },
             name: 'Links',
         })
     })

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -66,11 +66,8 @@ interface LinkPattern {
 const links: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
         return {
-            features: {
-                annotations: {
-                    implements: true,
-                    selectors: settings.links?.map(({ path }) => ({ path })) || [],
-                },
+            annotations: {
+                selectors: settings.links?.map(({ path }) => ({ path })) || [],
             },
             name: 'Links',
         }

--- a/provider/links/index.ts
+++ b/provider/links/index.ts
@@ -65,7 +65,15 @@ interface LinkPattern {
  */
 const links: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
-        return { selector: settings.links?.map(({ path }) => ({ path })) || [], name: 'Links' }
+        return {
+            features: {
+                annotations: {
+                    implements: true,
+                    selectors: settings.links?.map(({ path }) => ({ path })) || [],
+                },
+            },
+            name: 'Links',
+        }
     },
 
     items(params: ItemsParams, settings: Settings): ItemsResult {
@@ -181,7 +189,7 @@ function interpolate(text: string, groups?: MatchGroup[]): string {
     }
     return text.replaceAll(/\$(\d+)|\$<([^>]+)>/g, (_, nStr: string, name: string) => {
         if (nStr) {
-            const n = parseInt(nStr, 10)
+            const n = Number.parseInt(nStr, 10)
             const group = groups.find(g => g.name === n)
             return group?.value ?? _
         }

--- a/provider/notion/index.test.ts
+++ b/provider/notion/index.test.ts
@@ -14,7 +14,6 @@ describe('notion', () => {
         }
 
         const mentions = await notion.mentions!({ query }, settings)
-        console.log(mentions)
         expect(mentions).not.toStrictEqual([])
 
         const mention = mentions[0]

--- a/provider/notion/index.ts
+++ b/provider/notion/index.ts
@@ -37,10 +37,8 @@ export type Settings = {
 const notion: Provider<Settings> = {
     meta(params: MetaParams, settings: Settings): MetaResult {
         return {
-            // empty since we don't provide any annotations.
-            selector: [],
             name: 'Notion',
-            features: { mentions: true },
+            features: { mentions: { implements: true } },
         }
     },
 

--- a/provider/notion/index.ts
+++ b/provider/notion/index.ts
@@ -38,7 +38,7 @@ const notion: Provider<Settings> = {
     meta(params: MetaParams, settings: Settings): MetaResult {
         return {
             name: 'Notion',
-            features: { mentions: { implements: true } },
+            mentions: {},
         }
     },
 

--- a/provider/prometheus/index.test.ts
+++ b/provider/prometheus/index.test.ts
@@ -15,7 +15,12 @@ describe('prometheus', () => {
 
     test('meta', async () => {
         expect(await prometheus.meta({}, SETTINGS)).toStrictEqual<MetaResult>({
-            selector: [{ path: '**/*.go' }],
+            features: {
+                annotations: {
+                    implements: true,
+                    selectors: [{ path: '**/*.go' }],
+                },
+            },
             name: 'Prometheus',
         })
     })

--- a/provider/prometheus/index.test.ts
+++ b/provider/prometheus/index.test.ts
@@ -15,11 +15,8 @@ describe('prometheus', () => {
 
     test('meta', async () => {
         expect(await prometheus.meta({}, SETTINGS)).toStrictEqual<MetaResult>({
-            features: {
-                annotations: {
-                    implements: true,
-                    selectors: [{ path: '**/*.go' }],
-                },
+            annotations: {
+                selectors: [{ path: '**/*.go' }],
             },
             name: 'Prometheus',
         })

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -59,11 +59,8 @@ interface MetricRegistrationPattern {
 const prometheus: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
         return {
-            features: {
-                annotations: {
-                    implements: true,
-                    selectors: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [],
-                },
+            annotations: {
+                selectors: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [],
             },
             name: 'Prometheus',
         }

--- a/provider/prometheus/index.ts
+++ b/provider/prometheus/index.ts
@@ -59,7 +59,12 @@ interface MetricRegistrationPattern {
 const prometheus: Provider<Settings> = {
     meta(_params: MetaParams, settings: Settings): MetaResult {
         return {
-            selector: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [],
+            features: {
+                annotations: {
+                    implements: true,
+                    selectors: settings.metricRegistrationPatterns?.map(({ path }) => ({ path })) || [],
+                },
+            },
             name: 'Prometheus',
         }
     },

--- a/provider/sentry/provider.test.ts
+++ b/provider/sentry/provider.test.ts
@@ -159,17 +159,15 @@ describe('provider.meta', () => {
     test('returns expected meta result', async () => {
         const metaResult = providerImplementation.meta()
         expect(metaResult).toEqual({
-            selector: [],
             name: 'Sentry issues',
-            features: {
-                mentions: true,
-            },
+            mentions: {},
+            annotations: { selectors: [] },
         })
     })
 
     test('returns empty selector', async () => {
         const metaResult = providerImplementation.meta()
-        expect(metaResult.selector).toHaveLength(0)
+        expect(metaResult.annotations?.selectors).toHaveLength(0)
     })
 
     test('returns correct name', async () => {
@@ -179,7 +177,7 @@ describe('provider.meta', () => {
 
     test('returns correct features', async () => {
         const metaResult = providerImplementation.meta()
-        expect(metaResult.features).toEqual({ mentions: true })
+        expect(metaResult.mentions).toEqual({})
     })
 })
 

--- a/provider/sentry/provider.ts
+++ b/provider/sentry/provider.ts
@@ -16,10 +16,10 @@ export const providerImplementation = {
     meta(): MetaResult {
         return {
             // We don't provide any annotations for now.
-            selector: [],
             name: 'Sentry issues',
-            features: {
-                mentions: true,
+            mentions: {},
+            annotations: {
+                selectors: [],
             },
         }
     },

--- a/provider/slack/index.ts
+++ b/provider/slack/index.ts
@@ -101,7 +101,7 @@ let slackChannelData: SlackChannelData = {
 
 const slackContext = {
     meta(): MetaResult {
-        return { name: 'Slack', features: { mentions: true } }
+        return { name: 'Slack', features: { mentions: { implements: true } } }
     },
 
     async initializeChannelList(settingsInput: Settings) {

--- a/provider/slack/index.ts
+++ b/provider/slack/index.ts
@@ -101,7 +101,7 @@ let slackChannelData: SlackChannelData = {
 
 const slackContext = {
     meta(): MetaResult {
-        return { name: 'Slack', features: { mentions: { implements: true } } }
+        return { name: 'Slack', mentions: {} }
     },
 
     async initializeChannelList(settingsInput: Settings) {

--- a/provider/sourcegraph-search/index.ts
+++ b/provider/sourcegraph-search/index.ts
@@ -21,10 +21,8 @@ const sourcegraphSearch: Provider = {
         return {
             // empty since we don't provide any annotations.
             name: 'Sourcegraph Search',
-            features: {
-                mentions: { implements: true },
-                annotations: { implements: true, selectors: [] },
-            },
+            mentions: {},
+            annotations: { selectors: [] },
         }
     },
 

--- a/provider/sourcegraph-search/index.ts
+++ b/provider/sourcegraph-search/index.ts
@@ -20,9 +20,11 @@ const sourcegraphSearch: Provider = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
         return {
             // empty since we don't provide any annotations.
-            selector: [],
             name: 'Sourcegraph Search',
-            features: { mentions: true },
+            features: {
+                mentions: { implements: true },
+                annotations: { implements: true, selectors: [] },
+            },
         }
     },
 

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -35,10 +35,15 @@ const storybook: Provider<Settings> = {
             return { name: 'Storybook' }
         }
         return {
-            selector: [
-                { path: '**/*.story.(t|j)s?(x)' },
-                { path: '**/*.(t|j)s(x)', contentContains: 'react' },
-            ],
+            features: {
+                annotations: {
+                    implements: true,
+                    selectors: [
+                        { path: '**/*.story.(t|j)s?(x)' },
+                        { path: '**/*.(t|j)s(x)', contentContains: 'react' },
+                    ],
+                },
+            },
             name: 'Storybook',
         }
     },

--- a/provider/storybook/index.ts
+++ b/provider/storybook/index.ts
@@ -35,14 +35,11 @@ const storybook: Provider<Settings> = {
             return { name: 'Storybook' }
         }
         return {
-            features: {
-                annotations: {
-                    implements: true,
-                    selectors: [
-                        { path: '**/*.story.(t|j)s?(x)' },
-                        { path: '**/*.(t|j)s(x)', contentContains: 'react' },
-                    ],
-                },
+            annotations: {
+                selectors: [
+                    { path: '**/*.story.(t|j)s?(x)' },
+                    { path: '**/*.(t|j)s(x)', contentContains: 'react' },
+                ],
             },
             name: 'Storybook',
         }

--- a/provider/web/index.ts
+++ b/provider/web/index.ts
@@ -13,10 +13,11 @@ import type {
 const urlFetcher: Provider = {
     meta(): MetaResult {
         return {
-            // empty since we don't provide any annotations.
-            selector: [],
             name: 'Web URLs',
-            features: { mentions: true },
+            features: {
+                mentions: { implements: true },
+                annotations: { implements: true, selectors: [] },
+            },
         }
     },
 

--- a/provider/web/index.ts
+++ b/provider/web/index.ts
@@ -14,10 +14,8 @@ const urlFetcher: Provider = {
     meta(): MetaResult {
         return {
             name: 'Web URLs',
-            features: {
-                mentions: { implements: true },
-                annotations: { implements: true, selectors: [] },
-            },
+            mentions: {},
+            annotations: { selectors: [] },
         }
     },
 


### PR DESCRIPTION
This PR modifies the `MetaResult` to the following:

- ~`mentions.kind` is the list of types of mention items the provider can return. For example github pr, issues, code search results.~
- `mentions.selectors` is the list of regex patterns, which if matches with the mention text would mean that the provider can return items for that. We will use it to get context items from all the supported providers for when the user pasts in a URL after @. 
- Whey we do not have `features.mentions: boolean | {}` ? because then you can not do `meta?.features?.mentions?.selector`. We will always have to check of the mentions type first. 
- Accordingly the `meta.selector` is moved to `meta.features.annotations.selectors`. 

``` typescript
export interface MetaResult {
    /**
     * The name of the provider.
     */
    name: string

        /**
         * Configuration for the mentions feature.
         */
        mentions?: {
            /**
             * A list of patterns matching the mention text for which the provider can return mentions
             */
            selectors?: MentionSelector[]
        }
        /**
         * Configuration for the annotations feature.
         */
        annotations?: {
            /**
             * A list of patterns matching the mention text for which the provider can return mentions
             */
            selectors?: AnnotationSelector[]
        }
}
```