### PR TITLE
provider: better search and default settings for devdocs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,9 +497,9 @@ importers:
       '@openctx/provider':
         specifier: workspace:*
         version: link:../../lib/provider
-      fuse.js:
-        specifier: ^7.0.0
-        version: 7.0.0
+      fuzzysort:
+        specifier: ^3.0.1
+        version: 3.0.1
       lru-cache:
         specifier: ^10.1.0
         version: 10.1.0
@@ -606,6 +606,12 @@ importers:
         specifier: workspace:*
         version: link:../../lib/provider
 
+  provider/sentry:
+    dependencies:
+      '@openctx/provider':
+        specifier: workspace:*
+        version: link:../../lib/provider
+
   provider/slack:
     dependencies:
       '@openctx/provider':
@@ -627,12 +633,6 @@ importers:
       '@types/server-destroy':
         specifier: ^1.0.3
         version: 1.0.3
-
-  provider/sentry:
-    dependencies:
-      '@openctx/provider':
-        specifier: workspace:*
-        version: link:../../lib/provider
 
   provider/sourcegraph-search:
     dependencies:
@@ -9233,9 +9233,8 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
-  /fuse.js@7.0.0:
-    resolution: {integrity: sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==}
-    engines: {node: '>=10'}
+  /fuzzysort@3.0.1:
+    resolution: {integrity: sha512-jpiSrv+j2GwtI13z3vzdBAD5m7iVH23spSZwJrD657dfr6jUV2Jyc5YuSPKirmTp9OqnJbHudPIBGIId1bCWmA==}
     dev: false
 
   /gaxios@6.5.0:

--- a/provider/devdocs/README.md
+++ b/provider/devdocs/README.md
@@ -9,13 +9,22 @@ Add the following to your settings in any OpenCtx client:
 ```json
 "openctx.providers": {
     // ...other providers...
+    "https://openctx.org/npm/@openctx/provider-devdocs": true,
+},
+```
+
+This will use the default documentation sets as used by https://devdocs.io/. To specify the documentation use a configuration like:
+
+```json
+"openctx.providers": {
+    // ...other providers...
     "https://openctx.org/npm/@openctx/provider-devdocs": {
         "urls": ["https://devdocs.io/go/", "https://devdocs.io/angular~16/"]
     }
 },
 ```
 
-A URL is any top-level documentation URL on https://devdocs.io/. 
+A URL is any top-level documentation URL on https://devdocs.io/.
 
 ## Development
 

--- a/provider/devdocs/index.test.ts
+++ b/provider/devdocs/index.test.ts
@@ -89,6 +89,27 @@ describe('devdocs', () => {
                 '</pre>'
         )
     })
+
+    test('missing documentation has no results', async () => {
+        const fixturesDir = path.join(__dirname, '__fixtures__')
+        const settings = {
+            urls: [url.pathToFileURL(fixturesDir).toString()],
+        }
+
+        const mentions = await devdocs.mentions!({ query: 'abortcontroller' }, settings)
+        expect(mentions).toHaveLength(0)
+    })
+
+    test.runIf(INTEGRATION)('integration abortcontroller top in default urls', async () => {
+        const settings = {}
+        const want = {
+            title: 'AbortController',
+            uri: 'https://devdocs.io/dom/abortcontroller',
+        }
+        const mentions = await devdocs.mentions!({ query: 'abortcontroller' }, settings)
+        expect(mentions).toContainEqual(want)
+        expect(mentions[0]).toEqual(want)
+    })
 })
 
 /**

--- a/provider/devdocs/index.ts
+++ b/provider/devdocs/index.ts
@@ -11,18 +11,26 @@ import { LRUCache } from 'lru-cache'
 import { parse } from 'node-html-parser'
 import { fetchDoc, fetchIndex } from './devdocs.js'
 
+const DEFAULT_URLS = [
+    'https://devdocs.io/css/',
+    'https://devdocs.io/html/',
+    'https://devdocs.io/http/',
+    'https://devdocs.io/javascript/',
+    'https://devdocs.io/dom/',
+]
+
 /**
  * Settings for the DevDocs OpenCtx provider.
  */
 export type Settings = {
     /**
-     * The list of URLs to serve.
+     * The list of URLs to serve. Defaults to DEFAULT_URLS.
      *
      * These should be top-level documentation URLs like https://devdocs.io/angular~16/ or https://devdocs.io/typescript/
      *
      * Additionally this supports file:// URLs for local development.
      */
-    urls: string[]
+    urls?: string[]
 }
 
 /**
@@ -42,7 +50,9 @@ const devdocs: Provider<Settings> = {
             return []
         }
 
-        const indexes = await Promise.all(settings.urls.map(url => getMentionIndex(url)))
+        const urls = settings.urls ?? DEFAULT_URLS
+
+        const indexes = await Promise.all(urls.map(url => getMentionIndex(url)))
         const entries = indexes.flatMap(index => {
             return index.fuse.search(query, { limit: 10 }).map(result => ({
                 score: result.score ?? 0,

--- a/provider/devdocs/package.json
+++ b/provider/devdocs/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@openctx/provider": "workspace:*",
-    "fuse.js": "^7.0.0",
+    "fuzzysort": "^3.0.1",
     "lru-cache": "^10.1.0",
     "node-html-parser": "^6.1.13"
   }

--- a/provider/devdocs/package.json
+++ b/provider/devdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-devdocs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Use documentation from https://devdocs.io (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/devdocs",


### PR DESCRIPTION
Now if you do not specify `urls` in your settings we will use the same defaults as DevDocs does.

Additionally the search was too fuzzy before. This lead to confusing behaviour where it looked like the integration was broken. Instead we switch to a more classic fuzzy search library.

Test Plan: tests where added to ensure fuzzy finder can find no results and that we work with the default docset. Additionally we assert that the top result on a known query.