### PR TITLE
provider: remove dependency on lru-cache for devdocs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
       fuzzysort:
         specifier: ^3.0.1
         version: 3.0.1
-      lru-cache:
-        specifier: ^10.1.0
-        version: 10.1.0
       node-html-parser:
         specifier: ^6.1.13
         version: 6.1.13

--- a/provider/devdocs/cache.ts
+++ b/provider/devdocs/cache.ts
@@ -1,0 +1,22 @@
+export class Cache<T> {
+    private cache: Map<string, { value: T }> = new Map()
+    private timeoutMS: number
+
+    constructor(opts: { ttlMS: number }) {
+        this.timeoutMS = opts.ttlMS
+    }
+
+    async getOrFill(key: string, fill: () => Promise<T>): Promise<T> {
+        const entry = this.cache.get(key)
+        if (entry) {
+            return entry.value
+        }
+
+        const value = await fill()
+
+        this.cache.set(key, { value })
+        setTimeout(() => this.cache.delete(key), this.timeoutMS)
+
+        return value
+    }
+}

--- a/provider/devdocs/package.json
+++ b/provider/devdocs/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@openctx/provider": "workspace:*",
     "fuzzysort": "^3.0.1",
-    "lru-cache": "^10.1.0",
     "node-html-parser": "^6.1.13"
   }
 }


### PR DESCRIPTION
I was exploring why the npm package was nearly half a megabyte uncompressed and noticed lru-cache was quite large. This commit replaces it with a very simple cache with TTL (which is how we were using lru-cache).

It turns out this doesn't actually make that huge of a difference for our uncompressed bundle.js size (460K to 424K). When looking at the lru-cache package its mostly duplicated documentation which should get stripped out of our bundle. However, I am keeping this change since I think it introduces a nicer API to use.

Test Plan: INTEGRATION=1 pnpm test