### PR TITLE
provider: more robust content extraction for devdocs

### DIFF
--- a/provider/devdocs/index.ts
+++ b/provider/devdocs/index.ts
@@ -95,25 +95,12 @@ const devdocs: Provider<Settings> = {
             ]
         }
 
-        const root = parse(content)
-
-        let last = root.querySelector(hash)!
-        const nodes = [last]
-        while (true) {
-            const next = last.nextElementSibling
-            if (!next || next.rawTagName === 'h2') {
-                break
-            }
-            last = next
-            nodes.push(last)
-        }
-
         return [
             {
                 title: mention.title,
                 url: mention.uri,
                 ai: {
-                    content: nodes.map(node => node.toString()).join(''),
+                    content: extractHashContent(content, hash),
                 },
             },
         ]
@@ -149,6 +136,23 @@ async function getMentionIndex(devdocsURL: string): Promise<MentionIndex> {
             entries: entries,
         }
     })
+}
+
+function extractHashContent(content: string, hash: string): string {
+    const root = parse(content)
+
+    let last = root.querySelector(hash)!
+    const nodes = [last]
+    while (true) {
+        const next = last.nextElementSibling
+        if (!next || next.rawTagName === 'h2') {
+            break
+        }
+        last = next
+        nodes.push(last)
+    }
+
+    return nodes.map(node => node.toString()).join('')
 }
 
 export default devdocs


### PR DESCRIPTION
From my manual testing the current logic is sufficient. However, I haven't exhaustively tested all docsets so the code is now more robust to a hash link (ie to a subsection of a page) working.

Test Plan: existing tests ensure we don't regress
