### PR TITLE
provider: print authorizeURL for google-docs/auth

### DIFF
--- a/provider/google-docs/auth.ts
+++ b/provider/google-docs/auth.ts
@@ -61,6 +61,7 @@ export function getAuthenticatedClient(): Promise<OAuth2Client> {
                 }
             })
             .listen(0, () => {
+                console.log("opening " + authorizeURL)
                 open(authorizeURL, { wait: false }).then(cp => cp.unref())
             })
         destroyer(server)

--- a/provider/google-docs/auth.ts
+++ b/provider/google-docs/auth.ts
@@ -61,7 +61,7 @@ export function getAuthenticatedClient(): Promise<OAuth2Client> {
                 }
             })
             .listen(0, () => {
-                console.log("opening " + authorizeURL)
+                console.log('opening ' + authorizeURL)
                 open(authorizeURL, { wait: false }).then(cp => cp.unref())
             })
         destroyer(server)


### PR DESCRIPTION
My default browser is not connected to work, so being able to copy paste this URL is useful. Most CLIs that do this sort of thing will also print the URL incase the "open" call fails.