### PR TITLE
bin: add convenience values for OPENCTX_CONFIG

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -23,6 +23,12 @@ $ openctx items https://example.com
    - ai.content: (575 characters)
 ```
 
+`OPENCTX_CONFIG` can be one of:
+- JSON object of config
+- Path to JSON config
+- Provider URI
+- Path to provider bundle
+
 ## Known issues
 
 - Using providers from JavaScript bundles fetched over HTTPS requires [Node 22](https://nodejs.org/api/esm.html#https-and-http-imports) and running with the `node --experimental-modules --experimental-network-imports` option. These experimental flags are set in the `openctx` CLI when it invokes `node`, so you *should* not need to manually pass these.


### PR DESCRIPTION
I find it a bit annoying to include fully formed JSON as the value for OPENCTX_CONFIG. As such I make it possible to instead be a path or just directly a provider URI.

Test Plan: Tested it with different values of OPENCTX_CONFIG. Here is one example:

``` shellsession
$ OPENCTX_CONFIG=../provider/devdocs/dist/bundle.js pnpm openctx meta
[{"name":"DevDocs","mentions":{},"providerUri":"file:///home/keegan/src/github.com/sourcegraph/openctx/provider/devdocs/dist/bundle.js"}]
```

