### PR TITLE
semgrep: package.json points to bundle.js

### DIFF
--- a/provider/semgrep/package.json
+++ b/provider/semgrep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-semgrep",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Semgrep OpenCtx provider",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/semgrep",
@@ -10,10 +10,10 @@
     "directory": "provider/semgrep"
   },
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/index.js",
+    "dist/bundle.js",
     "dist/index.d.ts"
   ],
   "sideEffects": false,


### PR DESCRIPTION
index.js won't include the dependencies, making the currently published npm package non functional.