### PR TITLE
Convert aliased imports to require statements

### DIFF
--- a/client/vscode-lib/src/util/esmToCommonJS.test.ts
+++ b/client/vscode-lib/src/util/esmToCommonJS.test.ts
@@ -14,11 +14,18 @@ describe('esmToCommonJS', () => {
         expect(esmToCommonJS(esm)).toBe(expected)
     })
 
+    test("aliased import statements", () => {
+        const esm = "import { foo as foo2 } from './foo.js'"
+        const expected = "const foo2 = require('./foo.js').foo;"
+        expect(esmToCommonJS(esm)).toBe(expected)
+    })
+
     test('namespace import statements', () => {
         const esm = "import * as foobar from './foobar.js'"
         const expected = "const foobar = require('./foobar.js');"
         expect(esmToCommonJS(esm)).toBe(expected)
     })
+
 
     test('default export identifiers', () => {
         const esm = 'export default foo'

--- a/client/vscode-lib/src/util/esmToCommonJS.test.ts
+++ b/client/vscode-lib/src/util/esmToCommonJS.test.ts
@@ -14,7 +14,7 @@ describe('esmToCommonJS', () => {
         expect(esmToCommonJS(esm)).toBe(expected)
     })
 
-    test("aliased import statements", () => {
+    test('aliased import statements', () => {
         const esm = "import { foo as foo2 } from './foo.js'"
         const expected = "const foo2 = require('./foo.js').foo;"
         expect(esmToCommonJS(esm)).toBe(expected)

--- a/client/vscode-lib/src/util/esmToCommonJS.test.ts
+++ b/client/vscode-lib/src/util/esmToCommonJS.test.ts
@@ -26,7 +26,6 @@ describe('esmToCommonJS', () => {
         expect(esmToCommonJS(esm)).toBe(expected)
     })
 
-
     test('default export identifiers', () => {
         const esm = 'export default foo'
         const expected = 'module.exports = foo'

--- a/client/vscode-lib/src/util/esmToCommonJS.ts
+++ b/client/vscode-lib/src/util/esmToCommonJS.ts
@@ -10,6 +10,10 @@ export function esmToCommonJS(esm: string): string {
     // Convert import statements.
     let cjs = esm.replace(/(?<=^|\b)import\s+(\w+)\s+from\s+['"](.+)['"]/gm, "const $1 = require('$2');")
     cjs = cjs.replace(
+        /(?<=^|\b)import\s+\{\s+([\w\d]+)\s+as\s+([\w\d]+)\s+\}\s+from\s+['"](.+)['"]/gm,
+        "const $2 = require('$3').$1;"
+    )
+    cjs = cjs.replace(
         /(?<=^|\b)import\s*\{\s*([\w\s,]+)\s*\}\s+from\s+['"](.+)['"]/gm,
         "const { $1} = require('$2');"
     )


### PR DESCRIPTION
Aliased imports, e.g. `import { foo2 as foo } from './foo.js'` are not allowed in CommonJS.

I ran into this problem because in my provider 2 different modules imported `dirname`, so in the final bundle the second import was aliased as `dirname2`, which breaks compilation.

### Test plan
- Added a test case to `esmToCommonJS.test.ts`
- Tested locally (replaced the problematic import statement in `bundle.js`)