### PR TITLE
Fix sidebar nav going over content

### DIFF
--- a/web/pages/docs/components/DocsLayout.tsx
+++ b/web/pages/docs/components/DocsLayout.tsx
@@ -24,7 +24,7 @@ export const DocsLayout: FunctionComponent<{ children: ReactNode }> = ({ childre
             <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8">
                 <NavMenu
                     contentPageInfos={pageContext.contentPageInfos}
-                    className="fixed inset-0 left-[max(0px,calc(50%-45rem))] right-auto top-[3.8125rem] z-20 hidden w-[19rem] pb-10 pl-8 pr-6 lg:block"
+                    className="fixed inset-0 left-[max(0px,calc(50%-45rem))] right-auto top-[3.8125rem] z-20 hidden w-[15rem] pb-10 pl-8 pr-6 lg:block"
                 />
                 <div className="mb-24 lg:pl-[19.6rem]">
                     <div className="mt-10">{children}</div>


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-2100/docs-page-sidebarscrollbar-overlaps-main-content-in-chrome-and-safari

![CleanShot 2024-06-07 at 15 59 27@2x](https://github.com/sourcegraph/openctx/assets/153/04ef1867-ff0d-43a3-91ed-55ea2466f08c)
