### PR TITLE
Fix `email` param in Jira readme

### DIFF
--- a/provider/jira/README.md
+++ b/provider/jira/README.md
@@ -12,7 +12,7 @@
     // ...other providers...
     "https://openctx.org/npm/@openctx/provider-jira": {
         "url": "https://<subdomain>.atlassian.net/",
-        "username": "<email-address>",
+        "email": "<email-address>",
         "apiToken": "<your-atlassian-api-token>",
     }
 },


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-2245/jira-openctx-docs-incorrectly-reference-host-instead-of-url