### PR TITLE
client: add ObserveOptions.errorHook

### DIFF
--- a/lib/client/src/api.test.ts
+++ b/lib/client/src/api.test.ts
@@ -55,7 +55,12 @@ const DUMMY_CLIENT: ProviderClient = {
 }
 
 describe('observeItems', () => {
-    const OPTS: Parameters<typeof observeItems>[2] = { emitPartial: false }
+    const OPTS: Parameters<typeof observeItems>[2] = {
+        emitPartial: false,
+        errorHook: (providerUri, err) => {
+            throw new Error('unexpected error from ' + providerUri + ' ' + err)
+        },
+    }
 
     test('simple', () => {
         testScheduler().run(({ cold, expectObservable }) => {
@@ -128,6 +133,15 @@ describe('observeItems', () => {
     })
 
     test('provider error', () => {
+        let errorHookCalled = 0
+        const optsExpectingError = {
+            ...OPTS,
+            errorHook: (providerUri: string, err: any) => {
+                errorHookCalled++
+                expect(providerUri).toBe('a')
+                expect(err.message).toBe('erroringProvider')
+            },
+        }
         testScheduler().run(({ cold, expectObservable }) => {
             const erroringProvider: ProviderClientWithSettings = {
                 uri: 'a',
@@ -168,7 +182,7 @@ describe('observeItems', () => {
                         ],
                     }),
                     FIXTURE_ITEMS_PARAMS,
-                    OPTS
+                    optsExpectingError
                 )
             ).toBe('a', {
                 a: [fixtureItem('b', 'a')],
@@ -176,6 +190,7 @@ describe('observeItems', () => {
                 c: [fixtureItem('b', 'c')],
             } satisfies Record<string, Item[]>)
         })
+        expect(errorHookCalled).toBe(1)
     })
 
     test('config changes', () => {
@@ -301,6 +316,15 @@ describe('observeAnnotations', () => {
     })
 
     test('provider error', () => {
+        let errorHookCalled = 0
+        const optsExpectingError = {
+            ...OPTS,
+            errorHook: (providerUri: string, err: any) => {
+                errorHookCalled++
+                expect(providerUri).toBe('a')
+                expect(err.message).toBe('erroringProvider')
+            },
+        }
         testScheduler().run(({ cold, expectObservable }) => {
             const erroringProvider: ProviderClientWithSettings = {
                 uri: 'a',
@@ -341,7 +365,7 @@ describe('observeAnnotations', () => {
                         ],
                     }),
                     FIXTURE_ANNOTATIONS_PARAMS,
-                    OPTS
+                    optsExpectingError
                 )
             ).toBe('a', {
                 a: [fixtureAnn('b', 'a')],
@@ -349,6 +373,7 @@ describe('observeAnnotations', () => {
                 c: [fixtureAnn('b', 'c')],
             } satisfies Record<string, Annotation[]>)
         })
+        expect(errorHookCalled).toBe(1)
     })
 
     test('config changes', () => {


### PR DESCRIPTION
This introduces a new option when calling an observable method on the client. It allows a caller to collect errors on the underlying providers.

Currently the client implementation when encountering an error in a provider will log it and then swallow it unbeknownst to the client. This is reasonable behaviour since we don't want one bad provider causing all of OpenCtx to fail. For example if the methods where to throw errors you wouldn't be able to collect the working provider results.

As an alternative I considered updating the return type of the client to either return the underlying type or an error. This ended up being quite a large change and didn't feel like it justified it for the extra burden it imposed on each call site. However, I can go that route so that each client explicitly handles errors.

Test Plan: the unit test was updated to ensure errorHook is not called for the happy path, and is called for the erroring provider. Additionally because we now no longer call console.error the unit test output is much cleaner when all tests pass.