### PR TITLE
client: introduce ProviderMethodOptions

### DIFF
--- a/bin/cli.mts
+++ b/bin/cli.mts
@@ -33,7 +33,7 @@ async function subcommandMeta(client: Client<Range>, args: string[]): Promise<vo
         usageFatal('Error: invalid args')
     }
     const [providerUri] = args
-    const meta = await client.meta({}, providerUri)
+    const meta = await client.meta({}, { providerUri })
 
     if (process.env.OUTPUT_JSON) {
         console.log(JSON.stringify(meta, null, 2))
@@ -56,7 +56,7 @@ async function subcommandMentions(client: Client<Range>, args: string[]): Promis
     }
     const [query, providerUri] = args
 
-    const mentions = await client.mentions({ query }, providerUri)
+    const mentions = await client.mentions({ query }, { providerUri })
 
     if (process.env.OUTPUT_JSON) {
         console.log(JSON.stringify(mentions, null, 2))
@@ -81,7 +81,7 @@ async function subcommandItems(client: Client<Range>, args: string[]): Promise<v
         mention = JSON.parse(mentionJSON)
     }
 
-    const items = await client.items({ message, mention }, providerUri)
+    const items = await client.items({ message, mention }, { providerUri })
     printItems(items)
 }
 
@@ -91,9 +91,9 @@ async function subcommandMentionItems(client: Client<Range>, args: string[]): Pr
     }
     const [query, itemIndex, providerUri] = args
 
-    const mentions = await client.mentions({ query }, providerUri)
-    const mention = mentions[parseInt(itemIndex ?? 0)]
-    const items = await client.items({ mention }, mention.providerUri)
+    const mentions = await client.mentions({ query }, { providerUri })
+    const mention = mentions[Number.parseInt(itemIndex ?? 0)]
+    const items = await client.items({ mention }, { providerUri: mention.providerUri })
     printItems(items)
 }
 

--- a/lib/client/src/api.ts
+++ b/lib/client/src/api.ts
@@ -22,7 +22,7 @@ import {
     startWith,
     tap,
 } from 'rxjs'
-import type { ClientEnv } from './client/client.js'
+import type { ClientEnv, ProviderMethodOptions } from './client/client.js'
 import type { ProviderClient } from './providerClient/createProviderClient.js'
 
 /**
@@ -48,23 +48,13 @@ export interface ProviderClientWithSettings {
     settings: ProviderSettings
 }
 
-export interface ObserveOptions {
+export interface ObserveOptions extends Pick<ProviderMethodOptions, 'errorHook'> {
     /**
      * Emit partial results immediately. If `false`, wait for all providers to return an initial
      * result before emitting. If the caller is consuming the result as a Promise (with only one
      * value), this should be `false`.
      */
     emitPartial: boolean
-
-    /**
-     * If set will be called each time a provider returns an error. Errors are
-     * only logged in the OpenCtx client since we do not want a badly configured
-     * provider causing all to fail. This allows a caller to do have other
-     * behaviours on failure.
-     *
-     * If errorHook is set console.error will not be called on the error.
-     */
-    errorHook?(providerUri: string, error: any): void
 }
 
 /**

--- a/lib/client/src/index.ts
+++ b/lib/client/src/index.ts
@@ -2,7 +2,13 @@ export type * from '@openctx/protocol'
 export type { Provider } from '@openctx/provider'
 export type * from '@openctx/schema'
 export { observeItems, type Annotation, type EachWithProviderUri } from './api.js'
-export { createClient, type AuthInfo, type Client, type ClientEnv } from './client/client.js'
+export {
+    createClient,
+    type AuthInfo,
+    type Client,
+    type ProviderMethodOptions as ClientCallOptions,
+    type ClientEnv,
+} from './client/client.js'
 export { type ConfigurationUserInput as ClientConfiguration } from './configuration.js'
 export type { Logger } from './logger.js'
 export { fetchProviderSource } from './providerClient/transport/module.js'


### PR DESCRIPTION
My last PR introducing errorHook did not expose it in the vscode controller. This commit does the larger change of making it possible to be set by callers. Currently all methods optionally take a providerUri which affects the behaviour. This is now replaced with the ProviderMethodOptions argument which contains the providerUri and the newly introduced errorHook.

The name choice of the word "Method" was used since that is what we call the underlying provider methods in our documentation.

Test Plan: CI will cover if we broke anything. Additionally ran the cli with mention-items since that tests providerUri being set. Surpisingly none of our tests seem to test providerUri being set, but our CI will cover the normal case of no options being set working.

  OPENCTX_CONFIG=../provider/devdocs/dist/bundle.js pnpm openctx mention-items 'AbortController'