### PR TITLE
vscode-lib: use errorHook to report errors

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "OpenCtx CLI",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/clients/cli",

--- a/client/vscode-lib/package.json
+++ b/client/vscode-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/vscode-lib",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "OpenCtx library for VS Code extensions",
   "license": "Apache-2.0",
   "repository": {

--- a/client/vscode-lib/src/controller.test.ts
+++ b/client/vscode-lib/src/controller.test.ts
@@ -11,17 +11,6 @@ export function createMockController(): MockedObject<Controller> {
         items: vi.fn(),
         observeAnnotations: vi.fn(),
         annotations: vi.fn(),
-        client: {
-            metaChanges: vi.fn(),
-            meta: vi.fn(),
-            mentions: vi.fn(),
-            mentionsChanges: vi.fn(),
-            itemsChanges: vi.fn(),
-            items: vi.fn(),
-            annotationsChanges: vi.fn(),
-            annotations: vi.fn(),
-            dispose: vi.fn(),
-        },
     }
 }
 

--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -117,12 +117,15 @@ export function createController({
         }
     }
 
+    const errorLog = (error: any) => {
+        console.error(error)
+        outputChannel.appendLine(error)
+    }
+
     // errorReporter contains a lot of logic and state on how we notify and log
     // errors, as well as state around if we should turn off a feature (see
     // skipIfImplicitAction)
-    const errorReporter = new ErrorReporterController(showErrorNotification, (error: any) => {
-        outputChannel.appendLine(error)
-    })
+    const errorReporter = new ErrorReporterController(showErrorNotification, errorLog)
     disposables.push(errorReporter)
 
     // Note: We distingiush between an explicit user action and an implicit

--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -129,6 +129,9 @@ export function createController({
     // one. Explicit user actions should always run and return errors.
     // Implicit actions may not run if they are erroring a lot. Currently only
     // annotations is implicit.
+    //
+    // Note: the client swallows errors, so the observable methods will report
+    // internal errors but the behaviour around skipping is poor.
 
     /**
      * The controller is passed to UI feature providers for them to fetch data.

--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -281,7 +281,7 @@ function createErrorNotifier(
     return async (providerUri: string | undefined, error: any) => {
         const name = await getName(providerUri)
         const message = name
-            ? `Error from OpenCtx provider ${name}: ${error}`
+            ? `Error from OpenCtx provider "${name}": ${error}`
             : `Error from OpenCtx: ${error}`
         const action = await vscode.window.showErrorMessage(message, ...actionItems)
         if (action) {

--- a/client/vscode-lib/src/util/cache.ts
+++ b/client/vscode-lib/src/util/cache.ts
@@ -1,0 +1,47 @@
+import * as timersPromises from 'timers/promises'
+
+export class Cache<T> {
+    private cache: Map<string, { value: T }> = new Map()
+    private ttlMs: number
+
+    constructor(opts: { ttlMs: number }) {
+        this.ttlMs = opts.ttlMs
+    }
+
+    async getOrFill(key: string, fill: () => Promise<T>): Promise<T> {
+        const entry = this.cache.get(key)
+        if (entry) {
+            return entry.value
+        }
+
+        const value = await fill()
+
+        this.cache.set(key, { value })
+        const timeout = setTimeout(() => this.cache.delete(key), this.ttlMs)
+        timeout.unref()
+
+        return value
+    }
+}
+
+/** resolves promise, but will return defaultValue if promise throws or takes longer than delay ms */
+export async function bestEffort<T>(
+    promise: Promise<T>,
+    opts: {
+        defaultValue: T
+        delay: number
+    }
+): Promise<T> {
+    const ac = new AbortController()
+    const timeout = timersPromises.setTimeout(opts.delay, opts.defaultValue, {
+        ref: false,
+        signal: ac.signal,
+    })
+    try {
+        return await Promise.race([promise, timeout])
+    } catch {
+        return opts.defaultValue
+    } finally {
+        ac.abort()
+    }
+}

--- a/client/vscode-lib/src/util/errorReporter.ts
+++ b/client/vscode-lib/src/util/errorReporter.ts
@@ -1,0 +1,121 @@
+import type { ProviderMethodOptions } from '@openctx/client'
+import { type Observable, type UnaryFunction, catchError, of, pipe, tap } from 'rxjs'
+import * as vscode from 'vscode'
+import type { ErrorWaiter } from './errorWaiter.js'
+
+const MIN_TIME_SINCE_LAST_ERROR = 1000 * 60 * 15 /* 15 min */
+
+interface PromiseErrorHook {
+    opts: ProviderMethodOptions
+    onfinally: () => void
+}
+
+interface ErrorReporter {
+    tapAndCatch: UnaryFunction<any, any>
+    /**
+     * Returns opts with errorHook set so we report swallowed errors. This
+     * should be used on observables.
+     *
+     * The client will swallow errors so aggregation works. This calls the
+     * same functions our observable error catchers would also call.
+     */
+    withObserveOpts: (opts?: ProviderMethodOptions) => ProviderMethodOptions
+    /**
+     * Returns opts with errorHook set so we report swallowed errors.
+     * Additionally returns an onfinally function to be used on the promise.
+     *
+     * The client will swallow errors so aggregation works. This calls the
+     * same functions our observable error catchers would also call.
+     */
+    withPromiseOpts: (opts?: ProviderMethodOptions) => PromiseErrorHook
+}
+
+export function createErrorReporter(
+    outputChannel: vscode.OutputChannel,
+    errorWaiter: ErrorWaiter,
+    errorNotificationMessage: string
+): ErrorReporter {
+    const errorTapObserver = {
+        next(): void {
+            errorWaiter.gotError(false)
+        },
+        error(): void {
+            // Show an error notification unless we've recently shown one (to avoid annoying
+            // the user).
+            const shouldNotify = errorWaiter.timeSinceLastError() > MIN_TIME_SINCE_LAST_ERROR
+            if (shouldNotify) {
+                showErrorNotification(outputChannel, errorNotificationMessage)
+            }
+
+            errorWaiter.gotError(true)
+        },
+    }
+    const errorCatcher = <T = any>(error: any): Observable<T[]> => {
+        outputChannel.appendLine(error)
+        return of([])
+    }
+
+    return {
+        tapAndCatch: pipe(tap(errorTapObserver), catchError(errorCatcher)),
+        withObserveOpts: (opts?: ProviderMethodOptions): ProviderMethodOptions => {
+            // TODO(keegan) because we swallow errors observers errorTapObserver
+            // will always mark success.
+            return withErrorHook(opts, (_providerUri, err) => {
+                errorCatcher(err)
+                errorTapObserver.error()
+            })
+        },
+        withPromiseOpts: (opts?: ProviderMethodOptions): PromiseErrorHook => {
+            // For promises we aggregate the errors for a single call and when
+            // the promise is complete we update errorTapObserver with success
+            // or failure. This is to prevent spamming errors if multiple
+            // providers have issues.
+            const errors: any[] = []
+            return {
+                opts: withErrorHook(opts, (_providerUri, err) => {
+                    errorCatcher(err)
+                    errorTapObserver.error()
+                }),
+                onfinally: () => {
+                    if (errors.length === 0) {
+                        errorTapObserver.next()
+                        return
+                    }
+
+                    const err = errors.length === 1 ? errors[0] : new AggregateError(errors)
+                    errorCatcher(err)
+                    errorTapObserver.error()
+                },
+            }
+        },
+    }
+}
+
+function withErrorHook(
+    opts: ProviderMethodOptions | undefined,
+    errorHook: (providerUri: string, err: any) => void
+): ProviderMethodOptions {
+    const parent = opts?.errorHook
+    return {
+        ...opts,
+        errorHook: (providerUri, err) => {
+            if (parent) {
+                parent(providerUri, err)
+            }
+            errorHook(providerUri, err)
+        },
+    }
+}
+
+function showErrorNotification(outputChannel: vscode.OutputChannel, errorMessage: string): void {
+    const OPEN_LOG = 'Open Log'
+    vscode.window
+        .showErrorMessage(errorMessage, {
+            title: OPEN_LOG,
+        } satisfies vscode.MessageItem)
+        .then(action => {
+            if (action?.title === OPEN_LOG) {
+                outputChannel.show()
+            }
+        })
+}

--- a/client/vscode-lib/src/util/errorWaiter.ts
+++ b/client/vscode-lib/src/util/errorWaiter.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-interface ErrorWaiter extends vscode.Disposable {
+export interface ErrorWaiter extends vscode.Disposable {
     ok(): boolean
     timeSinceLastError(): number
     gotError(isError: boolean): void

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "openctx",
   "private": true,
   "displayName": "OpenCtx",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/logomark-v0.png",

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -6,8 +6,10 @@ import { getAuthInfo, secretsChanges } from './authInfo.js'
  * Start the extension, watching all relevant configuration and secrets for changes.
  */
 export function activate(
-    context: Pick<vscode.ExtensionContext, 'secrets' | 'subscriptions'>
+    context: Pick<vscode.ExtensionContext, 'extension' | 'secrets' | 'subscriptions'>
 ): ExtensionApiForTesting | null {
+    const extensionId = context.extension.id
+
     const outputChannel = vscode.window.createOutputChannel('OpenCtx')
     context.subscriptions.push(outputChannel)
 
@@ -20,6 +22,7 @@ export function activate(
         disposable: disposable1,
     } = createController({
         secrets,
+        extensionId,
         outputChannel,
         getAuthInfo,
         features: {

--- a/lib/client/package.json
+++ b/lib/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/client",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "OpenCtx client library",
   "license": "Apache-2.0",
   "repository": {

--- a/lib/client/src/api.ts
+++ b/lib/client/src/api.ts
@@ -80,10 +80,10 @@ function observeProviderCall<R>(
                               .pipe(
                                   emitPartial ? startWith(null) : tap(),
                                   catchError(error => {
-                                      logger?.(`failed to call provider: ${error}`)
                                       if (errorHook) {
                                           errorHook(uri, error)
                                       } else {
+                                          logger?.(`failed to call provider: ${error}`)
                                           console.error(error)
                                       }
                                       return of(null)

--- a/lib/client/src/client/client.ts
+++ b/lib/client/src/client/client.ts
@@ -132,7 +132,8 @@ export interface ProviderMethodOptions {
      * provider causing all to fail. This allows a caller to do have other
      * behaviours on failure.
      *
-     * If errorHook is set console.error will not be called on the error.
+     * If errorHook is set console.error and the logger will not be called on
+     * the error.
      */
     errorHook?(providerUri: string, error: any): void
 }


### PR DESCRIPTION
This commit factors out the error reporting logic inside of createController into an errorReporter interface. ErrorReporter also provides functionality so we can use the errorHooks.

From my testing, it is useful to do error reporting per method. For example a misconfigured provider will trip the errorWaiter, leading to errors when calling mentions not being reported.

Test Plan: linked openctx into cody and tested with my usual providers, a missing provider and a provider which throws an error mentions. I observed on cody chat startup complaints about the missing provider and complaints again when the error provider is called for mentions.

https://github.com/sourcegraph/openctx/assets/187831/858fabde-dec6-4375-98b3-bd3f1db0b41f