### PR TITLE
vscode-lib: add prepublishOnly step

### DIFF
--- a/client/vscode-lib/package.json
+++ b/client/vscode-lib/package.json
@@ -19,7 +19,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest"
+    "test": "vitest",
+    "prepublishOnly": "tsc --build --clean && pnpm run build"
   },
   "dependencies": {
     "@openctx/client": "workspace:*",


### PR DESCRIPTION
Only way I could convince pnpm to create a dist dir.