### PR TITLE
client: introduce preloadDelay

### DIFF
--- a/client/vscode-lib/package.json
+++ b/client/vscode-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/vscode-lib",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "OpenCtx library for VS Code extensions",
   "license": "Apache-2.0",
   "repository": {

--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -47,6 +47,7 @@ export function createController({
     getAuthInfo,
     features,
     providers,
+    preloadDelay,
 }: {
     secrets: Observable<vscode.SecretStorage> | vscode.SecretStorage
     extensionId: string
@@ -54,6 +55,7 @@ export function createController({
     getAuthInfo?: (secrets: vscode.SecretStorage, providerUri: string) => Promise<AuthInfo | null>
     features: { annotations?: boolean; statusBar?: boolean }
     providers?: ImportedProviderConfiguration[]
+    preloadDelay?: number
 }): {
     controller: Controller
     apiForTesting: ExtensionApiForTesting
@@ -100,6 +102,7 @@ export function createController({
         logger: message => outputChannel.appendLine(message),
         importProvider,
         providers,
+        preloadDelay,
     })
 
     const errorLog = (error: any) => {

--- a/lib/client/package.json
+++ b/lib/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/client",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "OpenCtx client library",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This setting allows us to preload the openctx providers after a delay (which could be zero milliseconds). The intention is for Cody to set a reasonable value here (5s?) so that when a user does the first @ mention the providers have already been fetched.

Test Plan: added logging and observed the preload completing before activating the cody chat panel. Then loaded the cody chat panel and instantly do a mention. All OpenCtx providers where immediate.

Part of https://linear.app/sourcegraph/issue/CODY-1898/preload-openctx-providers-for-faster-user-typing