### PR TITLE
protocol: add meta.mentions.label

### DIFF
--- a/lib/protocol/package.json
+++ b/lib/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/protocol",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "OpenCtx client/provider protocol",
   "license": "Apache-2.0",
   "repository": {

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -152,6 +152,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "label": {
+              "description": "The label that is shown when a user wants to query mentions. For example `Search...` or `Paste Linear URL`.",
+              "type": "string"
+            },
             "selectors": {
               "description": "The list of regex patterns for triggering mentions for the provider when users directly types a matching text, for example a url, allowing the user to bypass choosing the provider manually.",
               "type": "array",

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -53,6 +53,10 @@ export interface MetaResult {
      */
     mentions?: {
         /**
+         * The label that is shown when a user wants to query mentions. For example `Search...` or `Paste Linear URL`.
+         */
+        label?: string
+        /**
          * The list of regex patterns for triggering mentions for the provider when users directly types a matching text, for example a url, allowing the user to bypass choosing the provider manually.
          */
         selectors?: MentionSelector[]

--- a/provider/azure-devops-workitems/index.ts
+++ b/provider/azure-devops-workitems/index.ts
@@ -55,7 +55,10 @@ const wiToItem = (workItem: SimpleWorkItem): Item => ({
 
 const azureDevOps: Provider = {
     meta(): MetaResult {
-        return { name: 'Azure DevOps Work Items', mentions: {} }
+        return {
+            name: 'Azure DevOps Work Items',
+            mentions: { label: 'Search by title, description or id...' },
+        }
     },
 
     async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {

--- a/provider/azure-devops-workitems/package.json
+++ b/provider/azure-devops-workitems/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openctx/provider-azure-devops-workitems",
   "private": false,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Azure DevOps Work Items (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/azure-devops-workitems",

--- a/provider/confluence/index.ts
+++ b/provider/confluence/index.ts
@@ -24,7 +24,7 @@ const checkSettings = (settings: Settings) => {
 
 const confluenceProvider: Provider = {
     meta(params: MetaParams, settings: Settings): MetaResult {
-        return { name: 'Confluence Pages', mentions: {} }
+        return { name: 'Confluence Pages', mentions: { label: 'Search by page title...' } }
     },
 
     async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {

--- a/provider/confluence/package.json
+++ b/provider/confluence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openctx/provider-confluence",
   "private": false,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Confluence (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/confluence",
@@ -13,7 +13,10 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist/bundle.js", "dist/index.d.ts"],
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",
@@ -24,4 +27,3 @@
     "@openctx/provider": "workspace:*"
   }
 }
-  

--- a/provider/devdocs/index.test.ts
+++ b/provider/devdocs/index.test.ts
@@ -8,6 +8,53 @@ import devdocs, { type Settings } from './index.js'
 const INTEGRATION = !!process.env.INTEGRATION
 
 describe('devdocs', () => {
+    test('meta', () => {
+        expect(devdocs.meta({}, {})).toEqual({
+            name: 'DevDocs',
+            mentions: { label: 'Search docs... (css, html, http, javascript, dom)' },
+        })
+
+        expect(
+            devdocs.meta(
+                {},
+                {
+                    urls: [
+                        'https://devdocs.io/angular~16/',
+                        'https://devdocs.io/css/',
+                        'https://devdocs.io/typescript/',
+                    ],
+                }
+            )
+        ).toEqual({
+            name: 'DevDocs',
+            mentions: { label: 'Search docs... (angular~16, css, typescript)' },
+        })
+
+        expect(devdocs.meta({}, { urls: ['https://devdocs.io/go/'] })).toEqual({
+            name: 'DevDocs',
+            mentions: { label: 'Search docs... (go)' },
+        })
+    })
+
+    test('meta malformed', () => {
+        expect(
+            devdocs.meta(
+                {},
+                {
+                    urls: [
+                        'https://devdocs.io/go',
+                        'https://github.com/sourcegraph/openctx/pull/152',
+                        'hello world',
+                        '',
+                    ],
+                }
+            )
+        ).toEqual({
+            name: 'DevDocs',
+            mentions: { label: 'Search docs... (go, 152)' },
+        })
+    })
+
     test('test page type', async () => {
         const fixturesDir = path.join(__dirname, '__fixtures__')
         const settings = {

--- a/provider/devdocs/index.ts
+++ b/provider/devdocs/index.ts
@@ -3,6 +3,7 @@ import type {
     ItemsResult,
     MentionsParams,
     MentionsResult,
+    MetaParams,
     MetaResult,
     Provider,
 } from '@openctx/provider'
@@ -37,10 +38,12 @@ export type Settings = {
  * An OpenCtx provider that fetches the content of a [DevDocs](https://devdocs.io/) entry.
  */
 const devdocs: Provider<Settings> = {
-    meta(): MetaResult {
+    meta(_params: MetaParams, settings: Settings): MetaResult {
+        const urls = settings.urls ?? DEFAULT_URLS
+        const slugs = urls.map(u => u.match(/\/([^/]*)\/?$/)?.at(1)).filter(Boolean)
         return {
             name: 'DevDocs',
-            mentions: {},
+            mentions: { label: `Search docs... (${slugs.join(', ')})` },
         }
     },
 

--- a/provider/devdocs/package.json
+++ b/provider/devdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-devdocs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Use documentation from https://devdocs.io (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/devdocs",

--- a/provider/github/package.json
+++ b/provider/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-github",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "GitHub OpenCtx provider",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/github",

--- a/provider/github/provider.ts
+++ b/provider/github/provider.ts
@@ -8,7 +8,7 @@ export const githubProvider: Provider<Settings> = {
     meta(): MetaResult {
         return {
             name: 'Github PRs & Issues',
-            mentions: {},
+            mentions: { label: 'Search issues and pull requests...' },
         }
     },
 

--- a/provider/google-docs/index.test.ts
+++ b/provider/google-docs/index.test.ts
@@ -17,9 +17,9 @@ describe('googleDocs', () => {
     }
 
     test('meta', async () => {
-        expect(await googleDocs.meta({}, SETTINGS)).toEqual({
+        expect(await googleDocs.meta({}, SETTINGS)).toStrictEqual({
             name: 'Google Docs',
-            mentions: {},
+            mentions: { label: 'Search by title or paste a URL...' },
         })
     })
 })

--- a/provider/google-docs/index.ts
+++ b/provider/google-docs/index.ts
@@ -32,7 +32,7 @@ const NUMBER_OF_DOCUMENTS_TO_FETCH = 10
  */
 const googleDocs: Provider<Settings> = {
     meta(): MetaResult {
-        return { name: 'Google Docs', mentions: {} }
+        return { name: 'Google Docs', mentions: { label: 'Search by title or paste a URL...' } }
     },
 
     async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {

--- a/provider/google-docs/package.json
+++ b/provider/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-google-docs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Google Docs context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {
@@ -11,7 +11,10 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist/bundle.js", "dist/index.d.ts"],
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "bundle": "tsc --build && esbuild --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",

--- a/provider/jira/index.ts
+++ b/provider/jira/index.ts
@@ -55,7 +55,7 @@ const issueToItem = (issue: Issue): Item => ({
 
 const jiraProvider: Provider = {
     meta(params: MetaParams, settings: Settings): MetaResult {
-        return { name: 'Jira Issues', mentions: {} }
+        return { name: 'Jira Issues', mentions: { label: 'Search by name, id or paste a URL...' } }
     },
 
     async mentions(params: MentionsParams, settings: Settings): Promise<MentionsResult> {

--- a/provider/jira/package.json
+++ b/provider/jira/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openctx/provider-jira",
   "private": false,
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Jira (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/jira",
@@ -13,7 +13,10 @@
   "type": "module",
   "main": "dist/bundle.js",
   "types": "dist/index.d.ts",
-  "files": ["dist/bundle.js", "dist/index.d.ts"],
+  "files": [
+    "dist/bundle.js",
+    "dist/index.d.ts"
+  ],
   "sideEffects": false,
   "scripts": {
     "bundle": "tsc --build && esbuild --log-level=error --bundle --format=esm --outfile=dist/bundle.js index.ts",

--- a/provider/semgrep/index.test.ts
+++ b/provider/semgrep/index.test.ts
@@ -24,8 +24,7 @@ describe('Semgrep provider', () => {
     test('meta', () => {
         const meta = semgrep.meta({}, settings)
 
-        expect(meta).toBeDefined()
-        expect(meta).toEqual({ name: 'Semgrep', mentions: {} })
+        expect(meta).toStrictEqual({ name: 'Semgrep', mentions: { label: 'Paste a URL...' } })
     })
 
     test('items', async () => {

--- a/provider/semgrep/index.ts
+++ b/provider/semgrep/index.ts
@@ -58,7 +58,7 @@ function aiPrompt(finding: Finding): string {
 
 const semgrep: Provider = {
     meta(params: MetaParams, settings: Settings): MetaResult {
-        return { name: 'Semgrep', mentions: {} }
+        return { name: 'Semgrep', mentions: { label: 'Paste a URL...' } }
     },
 
     items(params: ItemsParams, settings: Settings): ItemsResult {

--- a/provider/semgrep/package.json
+++ b/provider/semgrep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-semgrep",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Semgrep OpenCtx provider",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/semgrep",

--- a/provider/sentry/package.json
+++ b/provider/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-sentry",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Use information from Sentry.io issues (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/sentry",

--- a/provider/sentry/provider.test.ts
+++ b/provider/sentry/provider.test.ts
@@ -158,26 +158,11 @@ Logger: N/A`
 describe('provider.meta', () => {
     test('returns expected meta result', async () => {
         const metaResult = providerImplementation.meta()
-        expect(metaResult).toEqual({
+        expect(metaResult).toStrictEqual({
             name: 'Sentry Issues',
-            mentions: {},
+            mentions: { label: 'Paste a URL...' },
             annotations: { selectors: [] },
         })
-    })
-
-    test('returns empty selector', async () => {
-        const metaResult = providerImplementation.meta()
-        expect(metaResult.annotations?.selectors).toHaveLength(0)
-    })
-
-    test('returns correct name', async () => {
-        const metaResult = providerImplementation.meta()
-        expect(metaResult.name).toBe('Sentry Issues')
-    })
-
-    test('returns correct features', async () => {
-        const metaResult = providerImplementation.meta()
-        expect(metaResult.mentions).toEqual({})
     })
 })
 

--- a/provider/sentry/provider.ts
+++ b/provider/sentry/provider.ts
@@ -17,7 +17,7 @@ export const providerImplementation = {
         return {
             // We don't provide any annotations for now.
             name: 'Sentry Issues',
-            mentions: {},
+            mentions: { label: 'Paste a URL...' },
             annotations: {
                 selectors: [],
             },

--- a/provider/slack/index.ts
+++ b/provider/slack/index.ts
@@ -15,7 +15,7 @@ let slackClient: undefined | SlackClient = undefined
 
 const slackContext = {
     meta(): MetaResult {
-        return { name: 'Slack', mentions: {} }
+        return { name: 'Slack', mentions: { label: 'Search by channel name...' } }
     },
 
     async initializeSlackClient(settingsInput: Settings) {

--- a/provider/slack/package.json
+++ b/provider/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-slack",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Slack context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {

--- a/provider/web/index.ts
+++ b/provider/web/index.ts
@@ -14,7 +14,7 @@ const urlFetcher: Provider = {
     meta(): MetaResult {
         return {
             name: 'Web URLs',
-            mentions: {},
+            mentions: { label: 'Paste a URL...' },
             annotations: { selectors: [] },
         }
     },

--- a/provider/web/package.json
+++ b/provider/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-web",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Use information from web pages (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/web",


### PR DESCRIPTION
The intention behind this field is this is the placeholder label that is shown when a user selects a provider for mentioning, but before they have searched anything.

Part of https://linear.app/sourcegraph/issue/CODY-2275/add-all-the-right-labels-for-provider-mentions-query-stats