### PR TITLE
linear-issues: correctly include assigned issues

### DIFF
--- a/provider/linear-issues/index.ts
+++ b/provider/linear-issues/index.ts
@@ -53,7 +53,7 @@ const linearIssues: Provider<Settings> = {
             const response = await linearApiRequest(viewerIssuesQuery, variables, settingsInput)
 
             const createdIssues = response.data.viewer.createdIssues.nodes as Issue[]
-            const assignedIssues = response.data.viewer.createdIssues.nodes as Issue[]
+            const assignedIssues = response.data.viewer.assignedIssues.nodes as Issue[]
             issues = dedupeWith([...assignedIssues, ...createdIssues], 'url')
         }
 

--- a/provider/linear-issues/package.json
+++ b/provider/linear-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-linear-issues",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Linear Issues context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This was a typo, previously we fetched assigned issues but accidently never read the field.