### PR TITLE
vscode-lib: expose vscode API via global

### DIFF
--- a/client/vscode-lib/package.json
+++ b/client/vscode-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/vscode-lib",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "OpenCtx library for VS Code extensions",
   "license": "Apache-2.0",
   "repository": {

--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -9,6 +9,7 @@ import type { ImportedProviderConfiguration } from '@openctx/client/src/configur
 import { type Observable, combineLatest, from, isObservable, map, mergeMap, of } from 'rxjs'
 import * as vscode from 'vscode'
 import { getClientConfiguration } from './configuration.js'
+import { initializeOpenCtxGlobal } from './global.js'
 import { type ExtensionApiForTesting, createApiForTesting } from './testing.js'
 import { createCodeLensProvider } from './ui/editor/codeLens.js'
 import { createHoverProvider } from './ui/editor/hover.js'
@@ -61,6 +62,8 @@ export function createController({
     apiForTesting: ExtensionApiForTesting
     disposable: vscode.Disposable
 } {
+    initializeOpenCtxGlobal()
+
     const disposables: vscode.Disposable[] = []
 
     const globalConfigurationChanges = observeWorkspaceConfigurationChanges('openctx')

--- a/client/vscode-lib/src/global.ts
+++ b/client/vscode-lib/src/global.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode'
+
+// dynamic imports don't work in node + vscode due to
+// https://github.com/microsoft/vscode-loader/issues/36
+//
+// So vscode-lib sets a global so providers can optionally access vscode APIs.
+
+interface Global {
+    openctx?: {
+        vscode?: typeof vscode
+    }
+}
+
+export function initializeOpenCtxGlobal() {
+    initializeGlobal(global as Global)
+}
+
+function initializeGlobal(global: Global) {
+    if (!global.openctx) {
+        global.openctx = { vscode }
+    }
+    global.openctx.vscode = vscode
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,6 +627,9 @@ importers:
       '@types/server-destroy':
         specifier: ^1.0.3
         version: 1.0.3
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.85.0
 
   provider/links:
     dependencies:

--- a/provider/linear-issues/package.json
+++ b/provider/linear-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-linear-issues",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Linear Issues context for code AI and editors (OpenCtx provider)",
   "license": "Apache-2.0",
   "repository": {
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc --build",
     "bundle:watch": "pnpm run bundle --watch",
-    "bundle": "esbuild --main-fields=module,main --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
+    "bundle": "esbuild --main-fields=module,main --external:vscode --log-level=error --platform=node --bundle --format=esm --outfile=dist/bundle.js index.ts",
     "prepublishOnly": "tsc --build --clean && pnpm run --silent bundle",
     "test": "vitest",
     "auth": "node --no-warnings=ExperimentalWarning --es-module-specifier-resolution=node --loader ts-node/esm/transpile-only auth.ts"
@@ -32,6 +32,7 @@
     "server-destroy": "^1.0.1"
   },
   "devDependencies": {
-    "@types/server-destroy": "^1.0.3"
+    "@types/server-destroy": "^1.0.3",
+    "@types/vscode": "^1.85.0"
   }
 }


### PR DESCRIPTION
Currently vscode doesn't support dynamic imports, so it isn't possible for a javascript provider to opt-in to more advanced user experience via the vscode APIs.

Until we can more easily opt-in to vscode support, we expose the vscode API via node's global object. We want to see what sort of APIs get used from vscode in providers, and will then likely evolve a first class editor abstraction.