### PR TITLE
vscode-lib: bump version to 0.0.13

### DIFF
--- a/client/vscode-lib/package.json
+++ b/client/vscode-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/vscode-lib",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "OpenCtx library for VS Code extensions",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I fat fingered publishing 0.0.12 without first bundling the latest version of the code into dist.