### PR TITLE
Add query selector config

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "OpenCtx CLI",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/clients/cli",

--- a/client/vscode-lib/package.json
+++ b/client/vscode-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/vscode-lib",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "OpenCtx library for VS Code extensions",
   "license": "Apache-2.0",
   "repository": {

--- a/lib/client/package.json
+++ b/lib/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/client",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "OpenCtx client library",
   "license": "Apache-2.0",
   "repository": {

--- a/lib/protocol/package.json
+++ b/lib/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/protocol",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "OpenCtx client/provider protocol",
   "license": "Apache-2.0",
   "repository": {

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -104,6 +104,18 @@
         }
       }
     },
+    "QuerySelector": {
+      "description": "List of regex patterns matching the query for which the provider can return context items.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "description": "The regex pattern matching the query for which the provider can return context items",
+          "type": "string"
+        }
+      }
+    },
     "MetaParams": {
       "type": "object",
       "additionalProperties": false,
@@ -146,6 +158,21 @@
         "name": {
           "description": "The name of the provider.",
           "type": "string"
+        },
+        "items": {
+          "description": "Configuration for providing context items.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "querySelectors": {
+              "description": "The list of regex patterns for matching with a query for which the provider can return context items",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/QuerySelector"
+              },
+              "tsType": "QuerySelector[]"
+            }
+          }
         },
         "mentions": {
           "description": "Configuration for the mentions feature.",

--- a/lib/protocol/src/openctx-protocol.schema.json
+++ b/lib/protocol/src/openctx-protocol.schema.json
@@ -27,6 +27,9 @@
       "$ref": "#/definitions/Mention"
     },
     {
+      "$ref": "#/definitions/MessageSelector"
+    },
+    {
       "$ref": "#/definitions/MentionSelector"
     },
     {
@@ -104,14 +107,14 @@
         }
       }
     },
-    "QuerySelector": {
-      "description": "List of regex patterns matching the query for which the provider can return context items.",
+    "MessageSelector": {
+      "description": "List of regex patterns matching a message for which the provider can return context items.",
       "type": "object",
       "additionalProperties": false,
       "required": ["pattern"],
       "properties": {
         "pattern": {
-          "description": "The regex pattern matching the query for which the provider can return context items",
+          "description": "The regex pattern matching a message for which the provider can return context items",
           "type": "string"
         }
       }
@@ -164,13 +167,13 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "querySelectors": {
-              "description": "The list of regex patterns for matching with a query for which the provider can return context items",
+            "messageSelectors": {
+              "description": "The list of regex patterns for matching with a message for which the provider can return context items",
               "type": "array",
               "items": {
-                "$ref": "#/definitions/QuerySelector"
+                "$ref": "#/definitions/MessageSelector"
               },
-              "tsType": "QuerySelector[]"
+              "tsType": "MessageSelector[]"
             }
           }
         },

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -49,6 +49,15 @@ export interface MetaResult {
      */
     name: string
     /**
+     * Configuration for providing context items.
+     */
+    items?: {
+        /**
+         * The list of regex patterns for matching with a query for which the provider can return context items
+         */
+        querySelectors?: QuerySelector[]
+    }
+    /**
      * Configuration for the mentions feature.
      */
     mentions?: {

--- a/lib/protocol/src/openctx-protocol.schema.ts
+++ b/lib/protocol/src/openctx-protocol.schema.ts
@@ -10,6 +10,7 @@ export type Protocol =
     | MetaParams
     | MetaResult
     | Mention
+    | MessageSelector
     | MentionSelector
     | AnnotationSelector
     | MentionsParams
@@ -53,9 +54,9 @@ export interface MetaResult {
      */
     items?: {
         /**
-         * The list of regex patterns for matching with a query for which the provider can return context items
+         * The list of regex patterns for matching with a message for which the provider can return context items
          */
-        querySelectors?: QuerySelector[]
+        messageSelectors?: MessageSelector[]
     }
     /**
      * Configuration for the mentions feature.
@@ -99,6 +100,15 @@ export interface Mention {
     data?: {
         [k: string]: unknown | undefined
     }
+}
+/**
+ * List of regex patterns matching a message for which the provider can return context items.
+ */
+export interface MessageSelector {
+    /**
+     * The regex pattern matching a message for which the provider can return context items
+     */
+    pattern: string
 }
 /**
  * List of regex patterns matching the mention text for which the provider can return mentions.

--- a/lib/provider/package.json
+++ b/lib/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "OpenCtx provider library",
   "license": "Apache-2.0",
   "repository": {

--- a/provider/hello-world/index.test.ts
+++ b/provider/hello-world/index.test.ts
@@ -7,6 +7,7 @@ describe('helloWorld', () => {
         expect(helloWorld.meta({}, {})).toStrictEqual<MetaResult>({
             name: '✨ Hello World!',
             annotations: {},
+            items: { messageSelectors: [{ pattern: '.*' }] },
         }))
 
     test('annotations', () =>

--- a/provider/hello-world/index.ts
+++ b/provider/hello-world/index.ts
@@ -16,7 +16,13 @@ import type {
  */
 const helloWorld: Provider = {
     meta(params: MetaParams, settings: ProviderSettings): MetaResult {
-        return { name: '✨ Hello World!', annotations: {} }
+        return {
+            name: '✨ Hello World!',
+            annotations: {},
+            items: {
+                messageSelectors: [{ pattern: '.*' }],
+            },
+        }
     },
 
     items(params: ItemsParams, settings: ProviderSettings): ItemsResult {

--- a/provider/hello-world/package.json
+++ b/provider/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openctx/provider-hello-world",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Hello World (OpenCtx provider)",
   "license": "Apache-2.0",
   "homepage": "https://openctx.org/docs/providers/hello-world",


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1721935489008949

A customer wants to return context items from their provider if the user's query matches some keywords. They wish to bypass the whole mentions process and return context items for queries on submission time. 

This makes sense and is useful. 

This PR adds `meta.items.querySelectors` which will be used at query evaluation time to match with query and then call `provider.items` for the matching providers to collect context items.  