### PR TITLE
expose async-generator client API

### DIFF
--- a/client/vscode-lib/src/controller.test.ts
+++ b/client/vscode-lib/src/controller.test.ts
@@ -5,12 +5,16 @@ export function createMockController(): MockedObject<Controller> {
     return {
         observeMeta: vi.fn(),
         meta: vi.fn(),
+        metaChanges__asyncGenerator: vi.fn(),
         observeMentions: vi.fn(),
         mentions: vi.fn(),
+        mentionsChanges__asyncGenerator: vi.fn(),
         observeItems: vi.fn(),
         items: vi.fn(),
+        itemsChanges__asyncGenerator: vi.fn(),
         observeAnnotations: vi.fn(),
         annotations: vi.fn(),
+        annotationsChanges__asyncGenerator: vi.fn(),
     }
 }
 

--- a/lib/client/src/api.ts
+++ b/lib/client/src/api.ts
@@ -15,6 +15,7 @@ import {
     catchError,
     combineLatest,
     defer,
+    distinctUntilChanged,
     from,
     map,
     mergeMap,
@@ -99,6 +100,7 @@ function observeProviderCall<R>(
                 : of([]),
         ),
         map(result => result.filter((v): v is EachWithProviderUri<R[]> => v !== null).flat()),
+        distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
         tap(items => {
             if (LOG_VERBOSE) {
                 logger?.(`got ${items.length} results: ${JSON.stringify(items)}`)

--- a/lib/client/src/client/testdata/simple.js
+++ b/lib/client/src/client/testdata/simple.js
@@ -1,6 +1,6 @@
 /** @type {import('@openctx/provider').Provider} */
 export default {
-    meta: () => ({ annotations: {} }),
+    meta: () => ({ name:'simple', annotations: {} }),
     items: () => [
         {
             title: 'A',

--- a/lib/client/src/client/testdata/simpleMeta.js
+++ b/lib/client/src/client/testdata/simpleMeta.js
@@ -1,0 +1,4 @@
+/** @type {import('@openctx/provider').Provider} */
+export default {
+    meta: (_, settings) => ({ name: `simpleMeta-${settings.nameSuffix}` }),
+}

--- a/lib/client/src/client/util.test.ts
+++ b/lib/client/src/client/util.test.ts
@@ -1,0 +1,71 @@
+import { Observable } from 'rxjs'
+import { describe, expect, test } from 'vitest'
+import { observableToAsyncGenerator } from './util.js'
+
+describe('observableToAsyncGenerator', () => {
+    test('observable that emits and completes', async () => {
+        const testObservable = new Observable<number>(observer => {
+            observer.next(1)
+            observer.next(2)
+            observer.complete()
+        })
+
+        const results: number[] = []
+        for await (const value of observableToAsyncGenerator(testObservable)) {
+            results.push(value)
+        }
+        expect(results).toEqual([1, 2])
+    })
+
+    test('observable that immediately completes', async () => {
+        const testObservable = new Observable<number>(observer => {
+            observer.complete()
+        })
+
+        const results: number[] = []
+        for await (const value of observableToAsyncGenerator(testObservable)) {
+            results.push(value)
+        }
+        expect(results).toEqual([])
+    })
+
+    test('observable that emits then errors', async () => {
+        const testObservable = new Observable<number>(observer => {
+            observer.next(1)
+            observer.error('x')
+        })
+
+        const results: number[] = []
+        let thrown: any
+        try {
+            for await (const value of observableToAsyncGenerator(testObservable)) {
+                results.push(value)
+            }
+        } catch (error) {
+            thrown = error
+        }
+        expect(results).toEqual([1])
+        expect(thrown).toBe('x')
+    })
+
+    test('with an AbortSignal', async () => {
+        const INTERVAL = 10
+        const testObservable = new Observable<number>(observer => {
+            let i = 1
+            const intervalHandle = setInterval(() => {
+                observer.next(i++)
+            }, INTERVAL)
+            return () => clearTimeout(intervalHandle)
+        })
+
+        const abortController = new AbortController()
+        const results: number[] = []
+        for await (const value of observableToAsyncGenerator(testObservable, abortController.signal)) {
+            results.push(value)
+            if (value === 5) {
+                abortController.abort()
+            }
+        }
+        expect(results).toEqual([1, 2, 3, 4, 5])
+    })
+})

--- a/lib/client/src/client/util.ts
+++ b/lib/client/src/client/util.ts
@@ -1,0 +1,63 @@
+import type { Observable } from 'rxjs'
+
+export async function* observableToAsyncGenerator<T>(
+    observable: Observable<T>,
+    signal?: AbortSignal,
+): AsyncGenerator<T> {
+    const queue: T[] = []
+    let thrown: unknown
+    let resolve: (() => void) | undefined
+    let reject: ((error: unknown) => void) | undefined
+    let finished = false
+
+    const subscription = observable.subscribe({
+        next: value => {
+            queue.push(value)
+            resolve?.()
+            resolve = undefined
+        },
+        error: error => {
+            thrown = error
+            reject?.(thrown)
+            reject = undefined
+        },
+        complete: () => {
+            finished = true
+            resolve?.()
+            resolve = undefined
+        },
+    })
+
+    let removeAbortListener: (() => void) | undefined = undefined
+    if (signal) {
+        const handler = () => {
+            resolve?.()
+            resolve = undefined
+            finished = true
+        }
+        signal.addEventListener('abort', handler)
+        removeAbortListener = () => {
+            signal.removeEventListener('abort', handler)
+        }
+    }
+
+    try {
+        while (true) {
+            if (queue.length > 0) {
+                yield queue.shift()!
+            } else if (thrown) {
+                throw thrown
+            } else if (finished) {
+                break
+            } else {
+                await new Promise<void>((res, rej) => {
+                    resolve = res
+                    reject = rej
+                })
+            }
+        }
+    } finally {
+        subscription.unsubscribe()
+        removeAbortListener?.()
+    }
+}


### PR DESCRIPTION
Previously, the client and controller only exposed a "watch" API using RxJS Observables so that callers could subscribe to and watch changes (to mentions, annotations, etc.). This required callers to depend on RxJS, which is a big dependency that can introduce complexity in their own applications. Now, there is a new API `xyzChanges__asyncGenerator` for each of `meta`, `mentions`, `items`, and `annotations` that lets callers just use native async generators. This API is experimental and may be changed without notice.