### PR TITLE
github: update example links

### DIFF
--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -33,13 +33,13 @@ By default, this provider talks to GitHub.com. Add the URL to your GitHub Enterp
 
 Then use the `@`-mention type **Github PRs & Issues** and search for issues or pull requests to include in context using the followining possible query examples:
 
-- <https://github.com/sourcegraph/sourcegraph/issues/1234>
-- <https://github.com/sourcegraph/sourcegraph/pull/1234>
-- <https://ghe.example.com/sourcegraph/sourcegraph/pull/1234>
-- github.com/sourcegraph/sourcegraph/issues/1234
-- ghe.example.com/sourcegraph/sourcegraph/issues/1234
-- sourcegraph/sourcegraph/issues/1234
-- sourcegraph/sourcegraph:1234
+- <https://github.com/facebook/react/issues/1234>
+- <https://github.com/facebook/react/pull/1234>
+- <https://ghe.example.com/facebook/react/pull/1234>
+- github.com/facebook/react/issues/1234
+- ghe.example.com/facebook/react/issues/1234
+- facebook/react/issues/1234
+- facebook/react:1234
 
 ## Development
 

--- a/provider/github/provider.ts
+++ b/provider/github/provider.ts
@@ -84,13 +84,13 @@ export const githubProvider: Provider<Settings> = {
 /** parseQuery parses a given user input and tries to extract the repo details and
  * item number from it.
  * Supported formats:
- * - https://github.com/sourcegraph/sourcegraph/issues/1234
- * - https://github.com/sourcegraph/sourcegraph/pull/1234
- * - https://ghe.example.com/sourcegraph/sourcegraph/pull/1234
- * - github.com/sourcegraph/sourcegraph/issues/1234
- * - ghe.example.com/sourcegraph/sourcegraph/issues/1234
- * - sourcegraph/sourcegraph/issues/1234
- * - sourcegraph/sourcegraph:1234
+ * - https://github.com/facebook/react/issues/1234
+ * - https://github.com/facebook/react/pull/1234
+ * - https://ghe.example.com/facebook/react/pull/1234
+ * - github.com/facebook/react/issues/1234
+ * - ghe.example.com/facebook/react/issues/1234
+ * - facebook/react/issues/1234
+ * - facebook/react:1234
  */
 export function parseQuery(query = ''): { owner: string; repoName: string; number: number } | null {
     try {


### PR DESCRIPTION
They are just example links so don't actually need to work, but got a report they no longer work. Update to most popular code repo on GitHub. 

Fixes https://github.com/sourcegraph/openctx/issues/203