### PR TITLE
improve observables usage

### DIFF
--- a/client/browser/src/contentScript/contentScript.main.ts
+++ b/client/browser/src/contentScript/contentScript.main.ts
@@ -6,7 +6,7 @@ import type { AnnotationsParams } from '@openctx/provider'
 import deepEqual from 'deep-equal'
 import { background } from '../browser-extension/web-extension-api/runtime.js'
 import './contentScript.main.css'
-import { combineLatest, distinctUntilChanged, mergeMap, throttleTime } from '@openctx/client/observable'
+import { combineLatest, distinctUntilChanged, switchMap, throttleTime } from '@openctx/client/observable'
 import type { Observable } from 'observable-fns'
 import { debugTap } from './debug.js'
 import { injectOnGitHubCodeView } from './github/codeView.js'
@@ -23,7 +23,7 @@ const INJECTORS: Injector[] = [injectOnGitHubCodeView, injectOnGitHubPullRequest
 
 const subscription = locationChanges
     .pipe(
-        mergeMap(location =>
+        switchMap(location =>
             combineLatest(INJECTORS.map(injector => injector(location, annotationsChanges))),
         ),
     )

--- a/client/browser/src/contentScript/github/codeView.ts
+++ b/client/browser/src/contentScript/github/codeView.ts
@@ -1,5 +1,12 @@
 import type { Annotation, AnnotationsParams } from '@openctx/client'
-import { EMPTY, combineLatest, debounceTime, mergeMap, startWith, tap } from '@openctx/client/observable'
+import {
+    EMPTY,
+    combineLatest,
+    debounceTime,
+    startWith,
+    switchMap,
+    tap,
+} from '@openctx/client/observable'
 import { createChipList } from '@openctx/ui-standalone'
 import { Observable, map } from 'observable-fns'
 import { toLineRangeStrings } from '../../shared/util/toLineRangeStrings.js'
@@ -33,7 +40,7 @@ export function injectOnGitHubCodeView(
         withDOMElement<HTMLTextAreaElement>('#read-only-cursor-text-area'),
         withDOMElement<HTMLElement>('react-app[app-name="react-code-view"]'),
     ]).pipe(
-        mergeMap(([cursorTextArea, reactCodeView]) => {
+        switchMap(([cursorTextArea, reactCodeView]) => {
             interface GitHubCodeView {
                 cursorTextArea: HTMLTextAreaElement
                 reactCodeView: HTMLElement

--- a/client/browser/src/contentScript/github/pullRequestFilesView.ts
+++ b/client/browser/src/contentScript/github/pullRequestFilesView.ts
@@ -1,5 +1,5 @@
 import type { Annotation, AnnotationsParams } from '@openctx/client'
-import { EMPTY, combineLatest, fromEvent, mergeMap, startWith, tap } from '@openctx/client/observable'
+import { EMPTY, combineLatest, fromEvent, startWith, switchMap, tap } from '@openctx/client/observable'
 import { createChipList } from '@openctx/ui-standalone'
 import { type Observable, filter, map } from 'observable-fns'
 import { DEBUG, debugTap } from '../debug.js'
@@ -30,7 +30,7 @@ export function injectOnGitHubPullRequestFilesView(
         withDOMElements<HTMLElement>('.diff-view .file'),
         clicksThatInvalidateDiffViewData.pipe(startWith(undefined)),
     ]).pipe(
-        mergeMap(([fileEls]) => {
+        switchMap(([fileEls]) => {
             const diffData = getDiffViewData(fileEls)
             if (DEBUG) {
                 console.log('diffData', diffData)
@@ -110,7 +110,7 @@ const clicksThatInvalidateDiffViewData: Observable<void> = fromEvent(document.bo
 
     // Wait for it to show up. Mark .blob-expanded elements that we've seen so that this works for
     // multiple expansions.
-    mergeMap(() =>
+    switchMap(() =>
         withDOMElements('tr.blob-expanded:not(.octx-seen)').pipe(
             tap(els => {
                 for (const el of els) {

--- a/client/vscode-lib/src/controller.ts
+++ b/client/vscode-lib/src/controller.ts
@@ -11,8 +11,8 @@ import {
 import {
     combineLatest,
     isObservableOrInteropObservable,
-    mergeMap,
     promiseToObservable,
+    switchMap,
 } from '@openctx/client/observable'
 import { Observable, type ObservableLike, map } from 'observable-fns'
 import * as vscode from 'vscode'
@@ -107,12 +107,12 @@ export function createController({
                 ? vscode.Uri.parse(resource)
                 : vscode.workspace.workspaceFolders?.[0]?.uri
             return observeWorkspaceConfigurationChanges('openctx', scope).pipe(
-                mergeMap(() => promiseToObservable(getConfiguration(scope))),
+                switchMap(() => promiseToObservable(getConfiguration(scope))),
             )
         },
         authInfo: getAuthInfo
             ? provider =>
-                  secrets.pipe(mergeMap(secrets => promiseToObservable(getAuthInfo(secrets, provider))))
+                  secrets.pipe(switchMap(secrets => promiseToObservable(getAuthInfo(secrets, provider))))
             : undefined,
         makeRange,
         logger: message => outputChannel.appendLine(message),

--- a/lib/client/src/api.test.ts
+++ b/lib/client/src/api.test.ts
@@ -351,7 +351,7 @@ describe('observeAnnotations', () => {
     test('config changes', async () => {
         const values = await allValuesFrom(
             observeAnnotations<Range>(
-                Observable.of(
+                observableOfTimedSequence(
                     [
                         {
                             uri: 'a',
@@ -362,6 +362,7 @@ describe('observeAnnotations', () => {
                             settings: {},
                         },
                     ],
+                    0,
                     [
                         {
                             uri: 'a',

--- a/lib/client/src/api.ts
+++ b/lib/client/src/api.ts
@@ -16,9 +16,9 @@ import {
     combineLatest,
     defer,
     distinctUntilChanged,
-    mergeMap,
     promiseOrObservableToObservable,
     startWith,
+    switchMap,
     tap,
 } from './misc/observable.js'
 import type { ProviderClient } from './providerClient/createProviderClient.js'
@@ -78,7 +78,7 @@ function observeProviderCall<R>(
     const EMIT_PARTIAL_SENTINEL: 'emit-partial-sentinel' = {} as any
 
     return providerClients.pipe(
-        mergeMap(providerClients =>
+        switchMap(providerClients =>
             providerClients && providerClients.length > 0
                 ? combineLatest(
                       providerClients.map(({ uri, providerClient, settings }) =>

--- a/lib/client/src/client/client.ts
+++ b/lib/client/src/client/client.ts
@@ -35,9 +35,9 @@ import {
     concatMap,
     distinctUntilChanged,
     firstValueFrom,
-    mergeMap,
     promiseOrObservableToObservable,
     shareReplay,
+    switchMap,
     take,
     timer,
 } from '../misc/observable.js'
@@ -288,7 +288,7 @@ export function createClient<R extends Range>(env: ClientEnv<R>): Client<R> {
                 }),
             )
             .pipe(
-                mergeMap(([configuration, providers]) =>
+                switchMap(([configuration, providers]) =>
                     configuration.providers.length > 0
                         ? combineLatest(
                               configuration.providers.map(({ providerUri, settings }) =>

--- a/lib/client/src/misc/observable.test.ts
+++ b/lib/client/src/misc/observable.test.ts
@@ -7,6 +7,7 @@ import {
     distinctUntilChanged,
     firstValueFrom,
     fromVSCodeEvent,
+    isEqualJSON,
     memoizeLastValue,
     observableOfSequence,
     observableOfTimedSequence,
@@ -387,5 +388,50 @@ describe('switchMap', () => {
 
         await done
         expect(values).toEqual(['a-1', 'a-2'])
+    })
+})
+
+describe('isEqualJSON', () => {
+    test('compares objects deeply', () => {
+        const obj1 = { a: 1, b: { c: 2 } }
+        const obj2 = { a: 1, b: { c: 2 } }
+        const obj3 = { a: 1, b: { c: 3 } }
+        const obj4 = { a: 1, b: { x: 3 } }
+
+        expect(isEqualJSON(obj1, obj2)).toBe(true)
+        expect(isEqualJSON(obj1, obj3)).toBe(false)
+        expect(isEqualJSON<unknown>(obj3, obj4)).toBe(false)
+    })
+
+    test('handles arrays', () => {
+        const arr1 = [1, 2, [3, 4]]
+        const arr2 = [1, 2, [3, 4]]
+        const arr3 = [1, 2, [3, 5]]
+
+        expect(isEqualJSON(arr1, arr2)).toBe(true)
+        expect(isEqualJSON(arr1, arr3)).toBe(false)
+
+        expect(isEqualJSON(['a'], { '0': 'a' })).toBe(false)
+        expect(isEqualJSON([undefined], { '0': undefined })).toBe(false)
+        expect(isEqualJSON([undefined], [null])).toBe(false)
+    })
+
+    test('handles null and undefined', () => {
+        expect(isEqualJSON(null, null)).toBe(true)
+        expect(isEqualJSON(undefined, undefined)).toBe(true)
+        expect(isEqualJSON(null, undefined)).toBe(false)
+    })
+
+    test('handles primitive types', () => {
+        expect(isEqualJSON(1, 1)).toBe(true)
+        expect(isEqualJSON('test', 'test')).toBe(true)
+        expect(isEqualJSON(true, true)).toBe(true)
+        expect(isEqualJSON<unknown>(1, '1')).toBe(false)
+    })
+
+    test('handles unset properties', () => {
+        expect(isEqualJSON({ a: undefined }, {})).toBe(true)
+        expect(isEqualJSON({}, { b: undefined })).toBe(true)
+        expect(isEqualJSON({}, { c: 123 })).toBe(false)
     })
 })

--- a/lib/client/src/misc/observable.ts
+++ b/lib/client/src/misc/observable.ts
@@ -452,6 +452,40 @@ export function distinctUntilChanged<T>(
     }
 }
 
+/**
+ * Whether {@link value} is equivalent to {@link other} in terms of JSON serialization.
+ */
+export function isEqualJSON<T>(value: T, other: T): boolean {
+    if (value === other) {
+        return true
+    }
+
+    if (value == null || other == null || typeof value !== 'object' || typeof other !== 'object') {
+        return false
+    }
+
+    const isValueArray = Array.isArray(value)
+    const isOtherArray = Array.isArray(other)
+    if (isValueArray !== isOtherArray) {
+        return false
+    }
+    if (isValueArray && isOtherArray) {
+        return (
+            value.length === other.length &&
+            value.every((value, index) => isEqualJSON(value, other[index]))
+        )
+    }
+
+    const allKeys = new Set([...Object.keys(value), ...Object.keys(other)])
+    for (const key of allKeys) {
+        if (!isEqualJSON((value as any)[key], (other as any)[key])) {
+            return false
+        }
+    }
+
+    return true
+}
+
 interface Observer<T> {
     next: (value: T) => void
     error: (err: any) => void
@@ -489,10 +523,6 @@ export function tap<T>(
 
 /** Sentinel value. */
 const NO_VALUES_YET: Record<string, never> = {}
-
-function isEqualJSON(a: unknown, b: unknown): boolean {
-    return JSON.stringify(a) === JSON.stringify(b)
-}
 
 export function mergeMap<T, R>(
     project: (value: T, index: number) => ObservableLike<R>,


### PR DESCRIPTION
- use custom isEqualJSON instead of JSON.stringify (for which key order matters)
- use switchMap instead of mergeMap to stop unwanted emissions