### PR TITLE
quieter provider errors with better origin information

### DIFF
--- a/client/vscode-lib/src/util/cache.ts
+++ b/client/vscode-lib/src/util/cache.ts
@@ -22,7 +22,10 @@ export class Cache<T> {
     }
 }
 
-/** resolves promise, but will return defaultValue if promise throws or takes longer than delay ms */
+/**
+ * Try to resolve {@link promise}, but return {@link opts.defaultValue} if it throws or takes longer than
+ * {@link opts.delay} ms.
+ */
 export async function bestEffort<T>(
     promise: Promise<T>,
     opts: {


### PR DESCRIPTION
- OpenCtx no longer uses vscode.window.showErrorMessage, which is annoying and louder than most provider errors deserve.
- The output channel includes information about which provider the error came from, to make debugging easier.