### PR TITLE
Update repositories to use sourcegraph/sourcegraph-public-snapshot

### DIFF
--- a/client/browser/README.md
+++ b/client/browser/README.md
@@ -18,8 +18,8 @@ Supported code hosts:
 
 After installing it in Chrome, visit the following pages to see it in action:
 
-- [Example code file on GitHub](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/repo-updater/internal/repoupdater/observability.go)
-- [Example pull request on GitHub](https://github.com/sourcegraph/sourcegraph/pull/58878/files)
+- [Example code file on GitHub](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/internal/repoupdater/client.go)
+- [Example pull request on GitHub](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/58878/files)
 
 Click the extension's icon to change your [configuration](https://openctx.org/docs/concepts#user-configuration).
 

--- a/client/browser/src/contentScript/github/codeView.ts
+++ b/client/browser/src/contentScript/github/codeView.ts
@@ -19,8 +19,8 @@ import { LINE_CHIPS_CLASSNAME, annsByLine, styledChipListParams } from '../openC
  *
  * Good URLs to test on:
  *
- * - Small file: https://github.com/sourcegraph/sourcegraph/blob/main/cmd/repo-updater/internal/repoupdater/observability.go
- * - Large file: https://github.com/sourcegraph/sourcegraph/blob/main/internal/repos/github.go#L1300
+ * - Small file: https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/internal/repoupdater/client.go
+ * - Large file: https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/internal/repos/github.go
  */
 export function injectOnGitHubCodeView(
     location: URL,

--- a/client/browser/src/contentScript/github/pullRequestFilesView.ts
+++ b/client/browser/src/contentScript/github/pullRequestFilesView.ts
@@ -11,9 +11,9 @@ import { LINE_CHIPS_CLASSNAME, annsByLine, styledChipListParams } from '../openC
  *
  * Good URLs to test on:
  *
- * - Small PR: https://github.com/sourcegraph/sourcegraph/pull/59084/files
- * - Medium PR: https://github.com/sourcegraph/sourcegraph/pull/58878/files
- * - Large PR: https://github.com/sourcegraph/sourcegraph/pull/58886/files
+ * - Small PR: https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/59084/files
+ * - Medium PR: https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/58878/files
+ * - Large PR: https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/58886/files
  */
 export function injectOnGitHubPullRequestFilesView(
     location: URL,

--- a/web/content/docs/clients/github.mdx
+++ b/web/content/docs/clients/github.mdx
@@ -25,8 +25,8 @@ _And when viewing files on GitHub._
 
 After installing the browser extension, visit the following pages to see it in action:
 
-- [Example code file on GitHub](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/repo-updater/internal/repoupdater/observability.go)
-- [Example pull request on GitHub](https://github.com/sourcegraph/sourcegraph/pull/58878/files)
+- [Example code file on GitHub](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/internal/repoupdater/client.go)
+- [Example pull request on GitHub](https://github.com/sourcegraph/sourcegraph-public-snapshot/pull/58878/files)
 
 Initially, the [`Hello World` provider](/docs/providers/hello-world) is enabled. Once you've confirmed that the browser extension is working, disable that provider by clicking on the OpenCtx extension icon in the Chrome toolbar and then changing the following line from `true` to `false`:
 

--- a/web/content/docs/start.mdx
+++ b/web/content/docs/start.mdx
@@ -48,8 +48,8 @@ See "[VS Code](/docs/clients/vscode)" for more information.
 1. Install [OpenCtx on the Chrome Web Store](https://chromewebstore.google.com/detail/indllinbfleghfhhaglfgohfceffendm).
 1. After installing it in Chrome, visit the following pages to see it in action:
 
-   - [Example code file on GitHub](https://github.com/sourcegraph/sourcegraph/blob/main/cmd/repo-updater/internal/repoupdater/observability.go)
-   - [Example pull request on GitHub](https://github.com/sourcegraph/sourcegraph/pull/58878/files)
+   - [Example code file on GitHub](https://github.com/sourcegraph/sourcegraph-public-snapshot/blob/main/internal/repoupdater/client.go)
+   - [Example pull request on GitHub](https://github.com/sourcegraph-public-snapshot/sourcegraph/pull/58878/files)
 
 1. Configure it to use other providers or patterns. See "[Browser extension](/docs/clients/browser-extension)" for details.
 

--- a/web/pages/docs/components/SourcegraphGettingStartedCommon.mdx
+++ b/web/pages/docs/components/SourcegraphGettingStartedCommon.mdx
@@ -3,9 +3,9 @@ import { Globe } from 'lucide-react'
 1.  Join our [Discord](/docs/community) and ask an admin to enable the `openctx` feature flag for your user account on [Sourcegraph.com](https://sourcegraph.com/search).
 1.  Visit a file on Sourcegraph that has OpenCtx items. Examples:
 
-        -   [SignInPage.tsx](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/client/web/src/auth/SignInPage.tsx)
-        -   [SignInPage.story.tsx](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/client/web/src/auth/SignInPage.story.tsx)
-        -   [conf.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/internal/conf/conf.go?L131:18)
+        -   [SignInPage.tsx](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-public-snapshot@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/client/web/src/auth/SignInPage.tsx)
+        -   [SignInPage.story.tsx](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-public-snapshot@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/client/web/src/auth/SignInPage.story.tsx)
+        -   [conf.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph-public-snapshot@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/internal/conf/conf.go?L131:18)
 
 1.  Toggle on the <Globe className="inline" size={18} /> button in the file header.
 1.  Look for and hover OpenCtx items, such as this one for a Prometheus metric:


### PR DESCRIPTION
`sourcegraph/sourcegraph` went private, so links and references became invalid.

I noticed the stale links in https://openctx.org/docs/clients/sourcegraph first: the example files are all linked to `sourcegraph/sourcegraph`, pinned to a commit.

This is one of the examples: [SignInPage.tsx](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6cdadefe437e0c7a1afe28da424982ebe72b3654/-/blob/client/web/src/auth/SignInPage.tsx)