### PR TITLE
pass settings in all HTTP provider invocations

### DIFF
--- a/lib/client/src/providerClient/transport/createTransport.test.ts
+++ b/lib/client/src/providerClient/transport/createTransport.test.ts
@@ -1,11 +1,13 @@
 import { afterEach } from 'node:test'
-import type { MetaResult, ResponseMessage } from '@openctx/protocol'
+import type { MetaResult, ProviderSettings, ResponseMessage } from '@openctx/protocol'
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 import { type ProviderTransport, createTransport } from './createTransport.js'
 
+const SETTINGS_FIXTURE: ProviderSettings = { a: 1 }
+
 async function expectProviderTransport(provider: ProviderTransport) {
-    expect(await provider.meta({}, {})).toEqual<MetaResult>({
+    expect(await provider.meta({}, SETTINGS_FIXTURE)).toEqual<MetaResult>({
         annotations: { selectors: [{ path: 'foo' }] },
         name: 'foo',
     })
@@ -67,6 +69,13 @@ describe('createTransport', () => {
             )
             const provider = createTransport('https://example.com/openctx', {})
             await expectProviderTransport(provider)
+
+            const body = await fetchMocker.requests()[0].json()
+            expect(body).toEqual({
+                method: 'meta',
+                params: {},
+                settings: SETTINGS_FIXTURE,
+            })
         })
 
         describe('errors', () => {

--- a/lib/client/src/providerClient/transport/http.ts
+++ b/lib/client/src/providerClient/transport/http.ts
@@ -85,9 +85,11 @@ export function createHttpTransport(
     }
 
     return {
-        meta: async params => send<MetaResult>({ method: 'meta', params }),
-        mentions: async params => send<MentionsResult>({ method: 'mentions', params }),
-        items: async params => send<ItemsResult>({ method: 'items', params }),
-        annotations: async params => send<AnnotationsResult>({ method: 'annotations', params }),
+        meta: async (params, settings) => send<MetaResult>({ method: 'meta', params, settings }),
+        mentions: async (params, settings) =>
+            send<MentionsResult>({ method: 'mentions', params, settings }),
+        items: async (params, settings) => send<ItemsResult>({ method: 'items', params, settings }),
+        annotations: async (params, settings) =>
+            send<AnnotationsResult>({ method: 'annotations', params, settings }),
     }
 }


### PR DESCRIPTION
The spec says that HTTP providers are invoked with a POST whose body includes the settings (https://openctx.org/docs/protocol). However, this was not happening; only the `params` were being sent. This fix makes it so that the `settings` are also passed.