### PR TITLE
Fix GitHub/GitLab brand capitalization

### DIFF
--- a/provider/github/README.md
+++ b/provider/github/README.md
@@ -31,7 +31,7 @@ By default, this provider talks to GitHub.com. Add the URL to your GitHub Enterp
 },
 ```
 
-Then use the `@`-mention type **Github PRs & Issues** and search for issues or pull requests to include in context using the followining possible query examples:
+Then use the `@`-mention type **GitHub PRs & Issues** and search for issues or pull requests to include in context using the followining possible query examples:
 
 - <https://github.com/facebook/react/issues/1234>
 - <https://github.com/facebook/react/pull/1234>


### PR DESCRIPTION
This change ensures consistent capitalization of the GitHub and GitLab brand names in Markdown documentation.

[_Created by Sourcegraph batch change `sqs/capitalize-brands-correctly`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/capitalize-brands-correctly)