### PR TITLE
fix: correct GitHub brand capitalization in provider

### DIFF
--- a/provider/github/provider.ts
+++ b/provider/github/provider.ts
@@ -7,7 +7,7 @@ import type { Settings } from './settings.js'
 export const githubProvider: Provider<Settings> = {
     meta(): MetaResult {
         return {
-            name: 'Github PRs & Issues',
+            name: 'GitHub PRs & Issues',
             mentions: { label: 'Search issues and pull requests...' },
         }
     },


### PR DESCRIPTION
This change ensures the GitHub brand name is capitalized correctly in the provider module.

<img width="385" alt="Zight 2025-01-09 at 9 25 31 AM png" src="https://github.com/user-attachments/assets/7a686364-b8f7-4386-8289-34fcf876ebf2" />
